### PR TITLE
fix: resolve 3 frontend blockers (P0)

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,0 +1,12 @@
+/* Global styles */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #1a1a2e;
+  color: #fff;
+}

--- a/frontend/src/components/galgame/SaveLoad.vue
+++ b/frontend/src/components/galgame/SaveLoad.vue
@@ -111,7 +111,7 @@ const handleLoad = async () => {
 
   try {
     const response = await axios.get(`/api/save/${selectedSave.value.id}`)
-    emit('loaded', response.data.data)
+    emit('load', response.data.data)
     alert('读档成功！')
   } catch (error) {
     console.error('Load failed:', error)

--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -293,7 +293,7 @@ const fetchSubjectInfo = async () => {
 const fetchActiveSession = async () => {
   try {
     // 获取最近的会话历史
-    const response = await axios.get(`/api/subjects/${subjectId.value}/start`, {
+    const response = await axios.post(`/api/subjects/${subjectId.value}/start`, {}, {
       headers: { Authorization: `Bearer ${authStore.token}` }
     })
 


### PR DESCRIPTION
## 关联 Issue
Closes #20

## 变更概述
修复 3 个阻塞性前端 Bug，均为一行修复。

## 改动清单
1. `frontend/src/assets/main.css` — 创建缺失文件，解决 Vite 启动崩溃
2. `frontend/src/components/galgame/SaveLoad.vue:114` — emit `'load'` 替代 `'loaded'`，匹配 Learning.vue 的 `@load` 监听
3. `frontend/src/views/Learning.vue:296` — `axios.post` 替代 `axios.get`，匹配后端 POST 端点

## 自查
- [x] main.css import 路径正确
- [x] SaveLoad emit 与 Learning.vue 监听一致
- [x] HTTP method 与后端路由定义一致