### PR TITLE
feat: Fuzzy Logic ZPD adaptive scaffold for dynamic prompt

### DIFF
--- a/backend/services/learning_engine.py
+++ b/backend/services/learning_engine.py
@@ -3,6 +3,7 @@
 import json
 import re
 from typing import List, Optional
+from sqlalchemy import func as sqlfunc
 from backend.services.llm.adapter import get_llm_adapter
 from backend.services.memory import memory_service
 from backend.services.dynamic_analyzer import DynamicAnalyzer
@@ -59,6 +60,8 @@ class LearningEngine:
         if emotion_type == "confusion" and mastery_level < 50:
             return 4
         if emotion_type == "confusion":
+            return 3
+        if emotion_type == "anxiety" and mastery_level > 60:
             return 3
         if emotion_type == "anxiety":
             return 4
@@ -247,7 +250,6 @@ class LearningEngine:
             # 4.6 Get average mastery_level for this subject (for scaffold computation)
             mastery_level = 50  # default
             if session.subject_id:
-                from sqlalchemy import func as sqlfunc
                 avg = db.query(sqlfunc.avg(ProgressTracking.mastery_level)).filter(
                     ProgressTracking.subject_id == session.subject_id,
                     ProgressTracking.user_id == session.user_id,


### PR DESCRIPTION
## 关联 Issue
Closes #14

## 变更概述
将静态情感策略映射替换为基于 Vygotsky ZPD 理论的自适应脚手架系统。融合情感状态 + FSRS 知识掌握度，动态计算教学支持等级（1-5）。

## 改动清单
- `backend/services/learning_engine.py`：
  - 移除 `EMOTION_STRATEGIES` dict
  - 新增 `SCAFFOLD_INSTRUCTIONS`（5 级教学行为描述）
  - 新增 `compute_scaffold_level(emotion, mastery)` 模糊逻辑决策
  - `_build_dynamic_layer()` 新增 mastery_level 参数
  - `process_message()` 查询 ProgressTracking 平均 mastery_level

## 脚手架决策示例

| 情感 | 掌握度 | 脚手架 | 行为 |
|------|--------|--------|------|
| frustration | 20 | 5 | 一步步带着走 |
| confusion | 40 | 4 | 给关键线索 |
| curiosity | 70 | 2 | 方向性暗示 |
| excitement | 80 | 1 | 完全自主 |

## 自查
- [x] 所有 8 类情感 + neutral 都有覆盖
- [x] mastery_level 默认 50（无数据时）
- [x] 不引入新依赖
- [x] 向后兼容：无 ProgressTracking 数据时退化为默认等级 3

## Reviewer 关注点
@reviewer 请看：
1. 模糊逻辑规则的阈值（30/50/60/70）是否合理
2. 用 subject 级别的平均 mastery 是否够精确，还是需要 topic 级别
3. scaffold 指令文本的措辞是否足够约束 LLM