### PR TITLE
feat: emotion trajectory visualization with ECharts

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -206,3 +206,63 @@ async def get_history(
         }
         for m in messages
     ]
+
+
+# List user's sessions
+@router.get("/sessions")
+async def list_sessions(
+    subject_id: Optional[int] = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    query = db.query(SessionModel).filter(
+        SessionModel.user_id == current_user.id
+    )
+    if subject_id:
+        query = query.filter(SessionModel.subject_id == subject_id)
+
+    sessions = query.order_by(SessionModel.started_at.desc()).all()
+    return [
+        {
+            "id": s.id,
+            "started_at": s.started_at,
+            "ended_at": s.ended_at,
+            "relationship_stage": s.relationship_stage,
+            "subject_name": s.subject.name if s.subject else None,
+        }
+        for s in sessions
+    ]
+
+
+# Get emotion trajectory for a session
+@router.get("/sessions/{session_id}/emotion_trajectory")
+async def get_emotion_trajectory(
+    session_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Return emotion data for all user messages in a session."""
+    session = db.query(SessionModel).filter(
+        SessionModel.id == session_id,
+        SessionModel.user_id == current_user.id
+    ).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    messages = db.query(ChatMessage).filter(
+        ChatMessage.session_id == session_id,
+        ChatMessage.sender_type == "user",
+        ChatMessage.emotion_analysis != None
+    ).order_by(ChatMessage.timestamp).all()
+
+    return [
+        {
+            "index": i + 1,
+            "timestamp": m.timestamp,
+            "emotion_type": m.emotion_analysis.get("emotion_type", "neutral"),
+            "valence": m.emotion_analysis.get("valence", 0.5),
+            "arousal": m.emotion_analysis.get("arousal", 0.5),
+            "confidence": m.emotion_analysis.get("confidence", 0.0),
+        }
+        for i, m in enumerate(messages)
+    ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "vue-router": "^4.2.5",
     "pinia": "^2.1.7",
     "axios": "^1.6.5",
-    "mermaid": "^11.4.0"
+    "mermaid": "^11.4.0",
+    "echarts": "^5.5.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.0",

--- a/frontend/src/components/EmotionTrajectory.vue
+++ b/frontend/src/components/EmotionTrajectory.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, nextTick, watch } from 'vue'
+import { ref, onMounted, onUnmounted, nextTick } from 'vue'
 import axios from 'axios'
 import * as echarts from 'echarts'
 import { useAuthStore } from '@/stores/auth'
@@ -222,6 +222,14 @@ const handleResize = () => {
 onMounted(() => {
   fetchSessions()
   window.addEventListener('resize', handleResize)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize)
+  valenceInstance?.dispose()
+  pieInstance?.dispose()
+  valenceInstance = null
+  pieInstance = null
 })
 
 defineProps<{

--- a/frontend/src/views/Archive.vue
+++ b/frontend/src/views/Archive.vue
@@ -54,6 +54,11 @@
         </div>
       </section>
 
+      <!-- 情感轨迹 -->
+      <section class="section">
+        <EmotionTrajectory />
+      </section>
+
       <!-- 存档管理 -->
       <section class="section">
         <div class="section-header">
@@ -110,6 +115,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
+import EmotionTrajectory from '@/components/EmotionTrajectory.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()


### PR DESCRIPTION
## 关联 Issue
Closes #16

## 变更概述
新增情感轨迹可视化组件，将学习会话中的情绪数据绘制为交互式图表。

## 改动清单
- `backend/api/routes/learning.py`：新增 GET /sessions 和 GET /sessions/{id}/emotion_trajectory
- `frontend/src/components/EmotionTrajectory.vue`：新组件，ECharts 效价曲线 + 情绪分布饼图
- `frontend/src/views/Archive.vue`：集成 EmotionTrajectory 组件
- `frontend/package.json`：新增 echarts ^5.5.0

## 自查
- [x] 8 种情绪都有颜色和中文标签映射
- [x] 响应式布局，移动端适配
- [x] 无会话数据时显示空状态
- [x] resize 事件处理

## Reviewer 关注点
@reviewer 请看：
1. /sessions 端点是否需要分页
2. ECharts 按需引入 vs 全量引入的包体积影响