### PR TITLE
fix: resolve 3 critical bugs (#23 #24 #25)

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -51,13 +51,20 @@ async def start_learning(
         TeacherPersona.is_active == True
     ).first()
 
+    # Get learner profile for this subject
+    learner_profile = db.query(LearnerProfile).filter(
+        LearnerProfile.user_id == current_user.id,
+        LearnerProfile.subject_id == subject_id,
+    ).first()
+
     # Create session
     db_session = SessionModel(
         tenant_id=current_user.tenant_id,
         subject_id=subject_id,
         user_id=current_user.id,
         system_prompt=teacher_persona.system_prompt_template if teacher_persona else None,
-        teacher_persona_id=teacher_persona.id if teacher_persona else None
+        teacher_persona_id=teacher_persona.id if teacher_persona else None,
+        learner_profile_id=learner_profile.id if learner_profile else None,
     )
     db.add(db_session)
     db.commit()

--- a/backend/services/learning_engine.py
+++ b/backend/services/learning_engine.py
@@ -273,10 +273,11 @@ class LearningEngine:
             ).order_by(ChatMessage.timestamp).all()
 
             # Convert to messages format for LLM
+            ROLE_MAP = {"user": "user", "teacher": "assistant"}
             messages = []
             for msg in chat_history:
                 messages.append({
-                    "role": msg.sender_type,
+                    "role": ROLE_MAP.get(msg.sender_type, "user"),
                     "content": msg.content
                 })
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,12 +2,18 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
+import { useAuthStore } from './stores/auth'
 
 import './assets/main.css'
 
 const app = createApp(App)
+const pinia = createPinia()
 
-app.use(createPinia())
+app.use(pinia)
 app.use(router)
+
+// Restore auth state from localStorage on app startup
+const authStore = useAuthStore(pinia)
+authStore.initAuth()
 
 app.mount('#app')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import type { RouteRecordRaw } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 
 const routes: RouteRecordRaw[] = [
   {
@@ -41,6 +42,15 @@ const routes: RouteRecordRaw[] = [
 const router = createRouter({
   history: createWebHistory(),
   routes
+})
+
+router.beforeEach((to, _from, next) => {
+  const authStore = useAuthStore()
+  if (to.name !== 'Login' && !authStore.isAuthenticated) {
+    next({ name: 'Login' })
+  } else {
+    next()
+  }
 })
 
 export default router


### PR DESCRIPTION
## 关联 Issue
Closes #23, Closes #24, Closes #25

## 变更概述
修复 3 个阻塞性 Bug，其中 2 个 P0 导致核心功能完全不可用。

## 改动清单

### #23 (P0) — 聊天第二条消息起必崩
- `backend/services/learning_engine.py:276`：添加 ROLE_MAP 将 "teacher" → "assistant"

### #24 (P0) — 页面刷新后 401
- `frontend/src/main.ts`：启动时调用 `authStore.initAuth()` 恢复 token
- `frontend/src/router/index.ts`：添加 `beforeEach` 守卫，未认证用户重定向到登录页

### #25 (P1) — 学习者画像始终为空
- `backend/api/routes/learning.py:54-59`：`start_learning()` 查询 LearnerProfile 并关联到 session

## 自查
- [x] ROLE_MAP 覆盖 user 和 teacher
- [x] initAuth 在 pinia 注册后、mount 前调用
- [x] 路由守卫排除 Login 页面
- [x] learner_profile 查询按 user_id + subject_id

## Reviewer 关注点
@reviewer 请看：
1. router 守卫中 `authStore.isAuthenticated` 的判断是否可靠（token 过期场景）
2. learner_profile 不存在时 session 正常创建（learner_profile_id=None）