### PR TITLE
fix: reuse active session to prevent chat history loss

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -45,6 +45,26 @@ async def start_learning(
     if not subject:
         raise HTTPException(status_code=404, detail="Subject not found")
 
+    # Reuse existing active session if available
+    existing = db.query(SessionModel).filter(
+        SessionModel.subject_id == subject_id,
+        SessionModel.user_id == current_user.id,
+        SessionModel.ended_at == None
+    ).order_by(SessionModel.started_at.desc()).first()
+
+    if existing:
+        teacher_persona = None
+        if existing.teacher_persona_id:
+            teacher_persona = db.query(TeacherPersona).filter(
+                TeacherPersona.id == existing.teacher_persona_id
+            ).first()
+        return {
+            "session_id": existing.id,
+            "teacher_persona": teacher_persona.name if teacher_persona else None,
+            "subject": subject.name,
+            "relationship_stage": existing.relationship_stage,
+        }
+
     # Get active teacher persona
     teacher_persona = db.query(TeacherPersona).filter(
         TeacherPersona.character_id == subject.character_id,
@@ -57,7 +77,7 @@ async def start_learning(
         LearnerProfile.subject_id == subject_id,
     ).first()
 
-    # Create session
+    # Create new session
     db_session = SessionModel(
         tenant_id=current_user.tenant_id,
         subject_id=subject_id,


### PR DESCRIPTION
## 关联 Issue
Closes #28

## 变更概述
`start_learning` 先查找已有活跃 session（ended_at=NULL），存在则直接返回，不再每次创建新 session。

## 改动清单
- `backend/api/routes/learning.py:48-68`：新增活跃 session 查找逻辑

## 自查
- [x] 已有活跃 session 时返回已有 session_id 和 relationship_stage
- [x] 无活跃 session 时照常创建新 session
- [x] 返回结构与新建 session 一致

## Reviewer 关注点
@reviewer 请看：是否需要提供"强制新建 session"的参数（如 force=true）用于用户主动重置