### PR TITLE
fix: emit type, Settings persistence, memory ID collision

### DIFF
--- a/backend/services/memory.py
+++ b/backend/services/memory.py
@@ -1,6 +1,7 @@
 """Memory service using ChromaDB for vector storage"""
 
 from typing import List, Optional
+import uuid
 import chromadb
 from chromadb.config import Settings
 
@@ -26,9 +27,7 @@ class MemoryService:
         """Add a memory to the vector store"""
         collection = self.get_or_create_collection(session_id)
 
-        # Generate a simple ID
-        import time
-        memory_id = f"memory_{int(time.time() * 1000)}"
+        memory_id = f"memory_{uuid.uuid4().hex[:16]}"
 
         collection.add(
             ids=[memory_id],

--- a/frontend/src/components/galgame/SaveLoad.vue
+++ b/frontend/src/components/galgame/SaveLoad.vue
@@ -65,7 +65,8 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  loaded: [data: any]
+  load: [data: any]
+  close: []
 }>()
 
 const mode = ref<'save' | 'load'>('save')

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
@@ -74,12 +74,29 @@ import { useAuthStore } from '@/stores/auth'
 const router = useRouter()
 const authStore = useAuthStore()
 
+const loadDisplayPrefs = () => {
+  const saved = localStorage.getItem('display_settings')
+  if (saved) {
+    try { return JSON.parse(saved) } catch { /* ignore */ }
+  }
+  return { typewriterEffect: true, autoScroll: true }
+}
+
+const displayPrefs = loadDisplayPrefs()
+
 const settings = ref({
   provider: 'claude',
   apiKey: '',
-  typewriterEffect: true,
-  autoScroll: true
+  typewriterEffect: displayPrefs.typewriterEffect,
+  autoScroll: displayPrefs.autoScroll
 })
+
+watch(() => [settings.value.typewriterEffect, settings.value.autoScroll], () => {
+  localStorage.setItem('display_settings', JSON.stringify({
+    typewriterEffect: settings.value.typewriterEffect,
+    autoScroll: settings.value.autoScroll,
+  }))
+}, { deep: true })
 
 const saving = ref(false)
 const saveMessage = ref('')


### PR DESCRIPTION
## 关联 Issue
Closes #30

## 变更概述
修复三个独立的小 Bug。

## 改动清单
- `frontend/src/components/galgame/SaveLoad.vue:67`：defineEmits 类型 `loaded` → `load`，新增 `close` 事件类型
- `frontend/src/views/Settings.vue:77-95`：用 localStorage 持久化 typewriterEffect 和 autoScroll
- `backend/services/memory.py:31`：用 uuid4 替代毫秒时间戳生成 memory ID

## 自查
- [x] emit 类型与实际调用一致
- [x] Settings 刷新后保留显示偏好
- [x] memory ID 不可能碰撞

## Reviewer 关注点
@reviewer 请看：Settings 持久化用 localStorage 是否足够，还是需要后端存储