### PR TITLE
fix: pass session_id to SaveLoad for non-empty saves

### DIFF
--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -74,6 +74,7 @@
     <SaveLoad
       v-if="showSaveLoad"
       :subject-id="subjectId"
+      :session-id="sessionId"
       @close="showSaveLoad = false"
       @load="handleLoadSave"
     />
@@ -119,6 +120,7 @@ const displayedText = ref('')
 const currentChoices = ref<string[]>([])
 const showToolConfirm = ref(false)
 const showSaveLoad = ref(false)
+const sessionId = ref<number | null>(null)
 const currentEmotion = ref('')
 const toolRequest = ref({ tool: '', query: '', reason: '' })
 const dialogArea = ref<HTMLElement | null>(null)
@@ -321,6 +323,7 @@ const fetchActiveSession = async () => {
     })
 
     if (response.data.session_id) {
+      sessionId.value = response.data.session_id
       // 获取会话历史
       const historyRes = await axios.get(
         `/api/sessions/${response.data.session_id}/history`,


### PR DESCRIPTION
## 关联 Issue
Closes #31

## 变更概述
Learning.vue 未将 session_id 传给 SaveLoad，导致存档时后端收到 null，存档文件 chat_history 为空。

## 改动清单
- `frontend/src/views/Learning.vue`：
  - 新增 `sessionId` ref
  - `fetchActiveSession` 中存储 `response.data.session_id`
  - SaveLoad 组件增加 `:session-id="sessionId"` prop

## 自查
- [x] sessionId 在 fetchActiveSession 成功后赋值
- [x] SaveLoad 接收 sessionId 并在 handleSave 中发送
- [x] 不影响其他功能

## Reviewer 关注点
@reviewer 请看：sessionId 是否也需要在 sendMessage 创建 auto-session 时更新