### PR TITLE
fix: SaveLoad close, progress FSRS preservation, stage stability

### DIFF
--- a/backend/api/routes/archive.py
+++ b/backend/api/routes/archive.py
@@ -504,7 +504,7 @@ def update_progress(
     if not db_progress:
         raise HTTPException(status_code=404, detail="Progress not found")
 
-    for key, value in progress.model_dump().items():
+    for key, value in progress.model_dump(exclude_unset=True).items():
         setattr(db_progress, key, value)
 
     db.commit()

--- a/backend/services/dynamic_analyzer.py
+++ b/backend/services/dynamic_analyzer.py
@@ -253,7 +253,25 @@ class DynamicAnalyzer:
             message_count = db.query(ChatMessage).filter(
                 ChatMessage.session_id == session_id
             ).count()
-            valence = emotion.get("valence", 0.5)
+
+            # Use average valence of recent messages instead of single message
+            recent_msgs = (
+                db.query(ChatMessage)
+                .filter(
+                    ChatMessage.session_id == session_id,
+                    ChatMessage.sender_type == "user",
+                    ChatMessage.emotion_analysis != None,
+                )
+                .order_by(ChatMessage.timestamp.desc())
+                .limit(10)
+                .all()
+            )
+            if recent_msgs:
+                valence = sum(
+                    m.emotion_analysis.get("valence", 0.5) for m in recent_msgs
+                ) / len(recent_msgs)
+            else:
+                valence = emotion.get("valence", 0.5)
 
             if message_count >= 30 and valence > 0.7:
                 return "partner"

--- a/frontend/src/components/galgame/SaveLoad.vue
+++ b/frontend/src/components/galgame/SaveLoad.vue
@@ -1,6 +1,8 @@
 <template>
+  <div class="save-load-overlay" @click.self="emit('close')">
   <div class="save-load-panel">
-    <div class="tabs">
+    <div class="panel-header">
+      <div class="tabs">
       <button
         :class="{ active: mode === 'save' }"
         @click="mode = 'save'"
@@ -13,6 +15,8 @@
       >
         读档
       </button>
+      </div>
+      <button class="close-btn" @click="emit('close')">✕</button>
     </div>
 
     <div class="save-list">
@@ -52,6 +56,7 @@
         确认读档
       </button>
     </div>
+  </div>
   </div>
 </template>
 
@@ -128,12 +133,45 @@ onMounted(fetchSaves)
 </script>
 
 <style scoped>
+.save-load-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
 .save-load-panel {
   background: rgba(0, 0, 0, 0.9);
   border: 2px solid #4a4a8a;
   border-radius: 12px;
   padding: 20px;
   min-width: 400px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.close-btn:hover {
+  color: #fff;
 }
 
 .tabs {


### PR DESCRIPTION
## 关联 Issue
Closes #32

## 变更概述
修复三个 P1 Bug：SaveLoad 无法关闭 + PUT progress 重置 FSRS + 关系阶段单消息回退。

## 改动清单
- `frontend/src/components/galgame/SaveLoad.vue`：添加 overlay 遮罩 + 关闭按钮 + emit('close')
- `backend/api/routes/archive.py:507`：`model_dump()` → `model_dump(exclude_unset=True)`
- `backend/services/dynamic_analyzer.py:252-272`：用最近 10 条用户消息的平均 valence 替代单条消息

## 自查
- [x] 点击遮罩或 ✕ 按钮都能关闭 SaveLoad
- [x] PUT progress 只更新传入的字段
- [x] 关系阶段不会因单条低 valence 消息回退

## Reviewer 关注点
@reviewer 请看：平均 valence 的窗口大小 10 是否合理