### PR TITLE
fix: add auth check to chat history endpoint (security)

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -213,6 +213,13 @@ async def get_history(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
+    session = db.query(SessionModel).filter(
+        SessionModel.id == session_id,
+        SessionModel.user_id == current_user.id,
+    ).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
     messages = db.query(ChatMessage).filter(
         ChatMessage.session_id == session_id
     ).order_by(ChatMessage.timestamp).all()


### PR DESCRIPTION
## 关联 Issue
Closes #37

## 变更概述
修复安全漏洞：GET /sessions/{id}/history 缺少 session 归属校验，任何认证用户可读取他人聊天记录。

## 改动清单
- `backend/api/routes/learning.py:210-215`：在查询 ChatMessage 前先验证 session.user_id == current_user.id

## 自查
- [x] 非 session 所有者请求返回 404
- [x] 与 end_session、emotion_trajectory 端点的鉴权模式一致

## Reviewer 关注点
@reviewer 请看：list_sessions 端点是否也需要类似检查（当前已按 user_id 过滤）