### PR TITLE
fix: remove duplicate settings endpoint from main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -49,9 +49,3 @@ app.include_router(save.router, prefix="/api", tags=["save"])
 @app.post("/api/voice", status_code=501)
 async def voice_input():
     return {"message": "Voice input not yet implemented"}
-
-
-# Settings endpoint placeholder
-@app.get("/api/settings")
-async def get_settings():
-    return {"message": "User settings endpoint"}


### PR DESCRIPTION
## 关联 Issue
Closes #39

## 变更概述
删除 main.py 中的 placeholder `GET /api/settings`，它与 archive.router 中的正式端点冲突，且函数名覆盖了 config.get_settings 导入。

## 改动清单
- `backend/main.py:54-57`：删除 settings placeholder

## 自查
- [x] archive.router 中的 GET /settings 不受影响
- [x] config.get_settings 导入不再被覆盖