### PR TITLE
fix: display teacher reply before tool confirmation

### DIFF
--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -222,7 +222,14 @@ const sendMessage = async () => {
 
     // 处理不同响应类型
     if (data.type === 'tool_request') {
-      // 显示工具确认弹窗
+      // Show teacher reply first (strip tool tags)
+      if (data.reply) {
+        const cleanReply = data.reply.replace(/<tool>[\s\S]*?<\/tool>/g, '').trim()
+        if (cleanReply) {
+          await startTyping(cleanReply)
+        }
+      }
+      // Then show tool confirmation
       toolRequest.value = {
         tool: data.tool || 'search',
         query: data.query || userMsg,


### PR DESCRIPTION
## 关联 Issue
Closes #34

## 变更概述
tool_request 类型回复时，先显示教师的文字回复（去掉 `<tool>` 标签），再弹出工具确认弹窗。之前教师回复被完全丢弃。

## 改动清单
- `frontend/src/views/Learning.vue:224-232`：strip tool 标签后用 startTyping 显示回复

## 自查
- [x] 去掉 `<tool>...</tool>` 后仍有文字时才显示
- [x] 空内容不触发 startTyping
- [x] 工具确认弹窗在回复显示后出现

## Reviewer 关注点
@reviewer 请看：tool_confirm 后端仍是 placeholder，整个工具链后续需要完善