### PR TITLE
fix: limit chat history to last 30 messages for LLM calls

### DIFF
--- a/backend/services/learning_engine.py
+++ b/backend/services/learning_engine.py
@@ -267,10 +267,15 @@ class LearningEngine:
                 mastery_level,
             )
 
-            # 6. Get chat history for context
-            chat_history = db.query(ChatMessage).filter(
-                ChatMessage.session_id == session_id
-            ).order_by(ChatMessage.timestamp).all()
+            # 6. Get recent chat history (limit to last 30 messages to control token usage)
+            chat_history = (
+                db.query(ChatMessage)
+                .filter(ChatMessage.session_id == session_id)
+                .order_by(ChatMessage.timestamp.desc())
+                .limit(30)
+                .all()
+            )
+            chat_history.reverse()  # restore chronological order
 
             # Convert to messages format for LLM
             ROLE_MAP = {"user": "user", "teacher": "assistant"}


### PR DESCRIPTION
## 关联 Issue
Closes #40

## 变更概述
将发送给 LLM 的聊天历史限制为最近 30 条消息，防止长会话 token 溢出和成本失控。旧上下文由 ChromaDB 记忆检索补充。

## 改动清单
- `backend/services/learning_engine.py:270-277`：查询改为 desc + limit(30) + reverse

## 自查
- [x] 最新 30 条按时间正序发送
- [x] ChromaDB retrieve 不受影响（独立查询）
- [x] 短会话（<30 条）行为不变

## Reviewer 关注点
@reviewer 请看：30 条是否合理，或是否应该改为可配置参数