### PR TITLE
fix: replace deprecated on_event, declarative_base, utcnow

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 from typing import Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 from backend.db.database import get_db
 from backend.api.routes.auth import get_current_user
 from backend.models.models import User, Session as SessionModel, ChatMessage, TeacherPersona, LearnerProfile, Subject
@@ -200,7 +200,7 @@ async def end_session(
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    session.ended_at = datetime.utcnow()
+    session.ended_at = datetime.now(timezone.utc)
     db.commit()
 
     return {"message": "Session ended"}

--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -19,9 +19,9 @@ def get_password_hash(password: str) -> str:
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=settings.access_token_expire_minutes)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_expire_minutes)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
     return encoded_jwt

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 from backend.core.config import get_settings
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from backend.core.config import get_settings
@@ -5,10 +7,31 @@ from backend.db.database import init_db
 
 settings = get_settings()
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup
+    init_db()
+    if settings.knowledge_graph_enabled:
+        from backend.services.knowledge_graph import knowledge_graph_service
+        knowledge_graph_service.configure(
+            neo4j_uri=settings.neo4j_uri,
+            neo4j_user=settings.neo4j_user,
+            neo4j_password=settings.neo4j_password,
+        )
+        await knowledge_graph_service.initialize()
+    yield
+    # Shutdown
+    if settings.knowledge_graph_enabled:
+        from backend.services.knowledge_graph import knowledge_graph_service
+        await knowledge_graph_service.close()
+
+
 app = FastAPI(
     title="Socratic Learning System",
     description="基于苏格拉底教学法的个性化学习系统",
-    version="1.0.0"
+    version="1.0.0",
+    lifespan=lifespan,
 )
 
 # CORS middleware
@@ -19,27 +42,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-
-@app.on_event("startup")
-async def startup_event():
-    init_db()
-    # Initialize knowledge graph if enabled
-    if settings.knowledge_graph_enabled:
-        from backend.services.knowledge_graph import knowledge_graph_service
-        knowledge_graph_service.configure(
-            neo4j_uri=settings.neo4j_uri,
-            neo4j_user=settings.neo4j_user,
-            neo4j_password=settings.neo4j_password,
-        )
-        await knowledge_graph_service.initialize()
-
-
-@app.on_event("shutdown")
-async def shutdown_event():
-    if settings.knowledge_graph_enabled:
-        from backend.services.knowledge_graph import knowledge_graph_service
-        await knowledge_graph_service.close()
 
 
 @app.get("/")


### PR DESCRIPTION
## 关联 Issue
Closes #54

## 变更概述
替换三处弃用 API，消除 DeprecationWarning 并确保未来版本兼容。

## 改动清单
- `backend/main.py`：`@on_event` → `lifespan` context manager
- `backend/db/database.py`：`sqlalchemy.ext.declarative` → `sqlalchemy.orm`
- `backend/core/security.py`：`utcnow()` → `now(timezone.utc)` (2 处)
- `backend/api/routes/learning.py`：`utcnow()` → `now(timezone.utc)` (1 处)

## 自查
- [x] lifespan 同时处理 startup 和 shutdown
- [x] 所有 utcnow 替换完毕（grep 确认）
- [x] declarative_base 功能不变