### PR TITLE
fix: restrict CORS origin and warn on default secret key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Required
+SECRET_KEY=generate-a-random-32-char-string
+DATABASE_URL=postgresql://user:password@localhost:5432/socratic_learning
+CORS_ORIGIN=http://localhost:5173
+
+# Optional
+NEO4J_URI=bolt://localhost:7687
+NEO4J_PASSWORD=your-password
+KNOWLEDGE_GRAPH_ENABLED=false

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,14 +1,20 @@
+import warnings
 from pydantic_settings import BaseSettings
 from functools import lru_cache
 from typing import Optional
+
+_DEFAULT_SECRET = "your-secret-key-change-in-production"
 
 
 class Settings(BaseSettings):
     # Database
     database_url: str = "postgresql://user:password@localhost:5432/socratic_learning"
 
+    # CORS
+    cors_origin: str = "http://localhost:5173"
+
     # JWT
-    secret_key: str = "your-secret-key-change-in-production"
+    secret_key: str = _DEFAULT_SECRET
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24  # 24 hours
 
@@ -45,4 +51,10 @@ class Settings(BaseSettings):
 
 @lru_cache
 def get_settings() -> Settings:
-    return Settings()
+    s = Settings()
+    if s.secret_key == _DEFAULT_SECRET:
+        warnings.warn(
+            "Using default SECRET_KEY! Set SECRET_KEY in .env for production.",
+            stacklevel=2,
+        )
+    return s

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,7 +37,7 @@ app = FastAPI(
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[settings.cors_origin],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## 关联 Issue
Closes #60

## 变更概述
修复两个部署前阻断性安全问题：CORS 允许任意来源 + 默认密钥无警告。

## 改动清单
- `backend/core/config.py`：新增 `cors_origin` 配置项，`get_settings()` 检测默认 SECRET_KEY 并发出 warning
- `backend/main.py`：`allow_origins=["*"]` → `allow_origins=[settings.cors_origin]`
- `.env.example`：列出所有必需和可选环境变量

## 自查
- [x] 开发环境默认 `http://localhost:5173` 不影响本地开发
- [x] 生产环境通过 CORS_ORIGIN 环境变量配置
- [x] 默认密钥不会静默上线（warning 提醒）
- [x] .env.example 不含真实密码