### PR TITLE
fix: add lock file sync check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      - name: Verify lock file in sync
+        run: |
+          cd frontend
+          npm install --package-lock-only
+          git diff --exit-code package-lock.json || {
+            echo "::error::package-lock.json is out of sync with package.json. Run 'cd frontend && npm install' and commit the updated lock file."
+            exit 1
+          }
       - name: Install and build
         run: |
           cd frontend


### PR DESCRIPTION
## 变更概述
CI frontend-build job 新增 lock file 同步检查。在 `npm ci` 之前运行 `npm install --package-lock-only` 并 `git diff --exit-code`，不同步时报清晰错误而非让 npm ci 崩溃。

## 改动
- `.github/workflows/ci.yml`：frontend-build 新增 "Verify lock file in sync" 步骤

## 自查
- [x] `--package-lock-only` 不安装依赖，只更新 lock file
- [x] `git diff --exit-code` 无差异返回 0，有差异返回 1
- [x] 错误消息告知开发者如何修复