### PR TITLE
fix: 2 critical Docker bugs + 3 deployment improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,21 +17,25 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@postgres:5432/${POSTGRES_DB:-socratic_learning}
       SECRET_KEY: ${SECRET_KEY:-change-me-in-production}
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost}
       CHROMA_HOST: chromadb
       CHROMA_PORT: 8000
       NEO4J_URI: bolt://neo4j:7687
       NEO4J_USER: ${NEO4J_USER:-neo4j}
       NEO4J_PASSWORD: ${NEO4J_PASSWORD:-socratic_learning}
+      KNOWLEDGE_GRAPH_ENABLED: ${KNOWLEDGE_GRAPH_ENABLED:-false}
+      SENTRY_DSN: ${SENTRY_DSN:-}
     depends_on:
       postgres:
         condition: service_healthy
       chromadb:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   postgres:
@@ -68,6 +72,7 @@ services:
 
   neo4j:
     image: neo4j:5.26-community
+    profiles: ["knowledge-graph"]
     ports:
       - "7474:7474"
       - "7687:7687"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,6 +10,11 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Health check proxy (for external monitoring)
+    location /health {
+        proxy_pass http://backend:8000/health;
+    }
+
     # Reverse proxy API requests to backend
     location /api/ {
         proxy_pass http://backend:8000/api/;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,6 +10,12 @@ echo ""
 echo "=== 苏格拉底学习系统 初始化 ==="
 echo ""
 
+# 前置检查
+for cmd in docker; do
+    command -v "$cmd" &>/dev/null || { echo "❌ 需要安装 $cmd"; exit 1; }
+done
+docker compose version &>/dev/null || { echo "❌ 需要 Docker Compose v2"; exit 1; }
+
 # 检查 .env 是否已存在
 if [[ -f .env ]]; then
     read -p ".env 已存在，是否覆盖？(y/N) " confirm


### PR DESCRIPTION
## 关联 Issue
Closes #77

## 变更概述
修复 2 个导致 Docker 部署完全不可用的 Critical bug，加 3 个改进。

## 改动清单

### Critical
| # | Bug | 修复 |
|---|-----|------|
| 1 | CORS_ORIGIN/KG_ENABLED/SENTRY_DSN 未传入容器 | docker-compose.yml 补充 3 个环境变量 |
| 2 | backend healthcheck 用 curl 但 python:3.11-slim 没有 curl | 改为 python urllib.request |

### 改进
| # | 改进 | 修复 |
|---|------|------|
| 3 | Neo4j 默认启动浪费 500MB | 添加 profiles: ["knowledge-graph"] |
| 4 | /health 只能直连 :8000 | nginx.conf 代理 /health |
| 5 | setup.sh 不检查 Docker | 添加前置检查 |

## 自查
- [x] CORS_ORIGIN 默认 http://localhost 与 setup.sh 一致
- [x] python urllib.request 在 python:3.11-slim 中可用
- [x] Neo4j 默认不启动，需 --profile knowledge-graph
- [x] backend healthcheck 添加 start_period: 15s 等待启动

## Reviewer 关注点
@reviewer 请看：
1. chromadb healthcheck 仍用 curl——chromadb/chroma 镜像是否有 curl？
2. start_period 15s 是否足够 alembic migrate + uvicorn 启动