### PR TITLE
fix: resolve all Ruff lint errors across backend

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -5,11 +5,11 @@ backend.db.database.Base.metadata for autogenerate support.
 """
 
 import sys
-from pathlib import Path
 from logging.config import fileConfig
+from pathlib import Path
 
-from sqlalchemy import engine_from_config, pool
 from alembic import context
+from sqlalchemy import engine_from_config, pool
 
 # Add project root to path so `from backend.xxx` imports work
 # env.py is at backend/alembic/env.py → parents[2] is project root

--- a/backend/alembic/versions/001_initial_schema.py
+++ b/backend/alembic/versions/001_initial_schema.py
@@ -4,15 +4,15 @@ Revision ID: 001
 Revises:
 Create Date: 2026-03-25
 """
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision: str = '001'
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/backend/api/routes/archive.py
+++ b/backend/api/routes/archive.py
@@ -1,11 +1,20 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from typing import Optional, List
-from datetime import datetime, timezone
-from backend.db.database import get_db
+from sqlalchemy.orm import Session
+
 from backend.api.routes.auth import get_current_user
-from backend.models.models import Character, TeacherPersona, LearnerProfile, Subject, LessonPlan, LearningDiary, ProgressTracking, User
+from backend.db.database import get_db
+from backend.models.models import (
+    Character,
+    LearnerProfile,
+    LearningDiary,
+    ProgressTracking,
+    Subject,
+    TeacherPersona,
+    User,
+)
 from backend.services import spaced_repetition
 
 router = APIRouter()
@@ -14,10 +23,10 @@ router = APIRouter()
 # Pydantic Schemas
 class CharacterCreate(BaseModel):
     name: str
-    avatar: Optional[str] = None
-    personality: Optional[str] = None
-    background: Optional[str] = None
-    speech_style: Optional[str] = None
+    avatar: str | None = None
+    personality: str | None = None
+    background: str | None = None
+    speech_style: str | None = None
 
 
 class CharacterResponse(CharacterCreate):
@@ -31,8 +40,8 @@ class TeacherPersonaCreate(BaseModel):
     character_id: int
     name: str
     version: str = "1.0"
-    traits: Optional[dict] = None
-    system_prompt_template: Optional[str] = None
+    traits: dict | None = None
+    system_prompt_template: str | None = None
     is_active: bool = False
 
 
@@ -44,11 +53,11 @@ class TeacherPersonaResponse(TeacherPersonaCreate):
 
 
 class LearnerProfileCreate(BaseModel):
-    subject_id: Optional[int] = None
-    learning_style: Optional[dict] = None
-    cognitive_traits: Optional[dict] = None
-    emotional_traits: Optional[dict] = None
-    knowledge_graph: Optional[dict] = None
+    subject_id: int | None = None
+    learning_style: dict | None = None
+    cognitive_traits: dict | None = None
+    emotional_traits: dict | None = None
+    knowledge_graph: dict | None = None
 
 
 class LearnerProfileResponse(LearnerProfileCreate):
@@ -62,8 +71,8 @@ class LearnerProfileResponse(LearnerProfileCreate):
 class SubjectCreate(BaseModel):
     character_id: int
     name: str
-    description: Optional[str] = None
-    target_level: Optional[str] = None
+    description: str | None = None
+    target_level: str | None = None
 
 
 class SubjectResponse(SubjectCreate):
@@ -89,7 +98,7 @@ class LearningDiaryCreate(BaseModel):
     subject_id: int
     date: datetime
     content: str
-    reflection: Optional[str] = None
+    reflection: str | None = None
 
 
 class LearningDiaryResponse(LearningDiaryCreate):
@@ -104,13 +113,13 @@ class ProgressTrackingCreate(BaseModel):
     subject_id: int
     topic: str
     mastery_level: int = 0
-    next_review: Optional[datetime] = None
+    next_review: datetime | None = None
 
 
 class ProgressTrackingResponse(ProgressTrackingCreate):
     id: int
     user_id: int
-    last_review: Optional[datetime] = None
+    last_review: datetime | None = None
 
     class Config:
         from_attributes = True
@@ -134,7 +143,7 @@ def create_character(
     return db_character
 
 
-@router.get("/character", response_model=List[CharacterResponse])
+@router.get("/character", response_model=list[CharacterResponse])
 def get_characters(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
@@ -217,9 +226,9 @@ def create_teacher_persona(
     return db_persona
 
 
-@router.get("/teacher_persona", response_model=List[TeacherPersonaResponse])
+@router.get("/teacher_persona", response_model=list[TeacherPersonaResponse])
 def get_teacher_personas(
-    character_id: Optional[int] = None,
+    character_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -311,9 +320,9 @@ def create_learner_profile(
     return db_profile
 
 
-@router.get("/learner_profile", response_model=List[LearnerProfileResponse])
+@router.get("/learner_profile", response_model=list[LearnerProfileResponse])
 def get_learner_profiles(
-    subject_id: Optional[int] = None,
+    subject_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -365,9 +374,9 @@ def create_subject(
     return db_subject
 
 
-@router.get("/subjects", response_model=List[SubjectResponse])
+@router.get("/subjects", response_model=list[SubjectResponse])
 def get_subjects(
-    character_id: Optional[int] = None,
+    character_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -449,9 +458,9 @@ def create_learning_diary(
     return db_diary
 
 
-@router.get("/learning_diary", response_model=List[LearningDiaryResponse])
+@router.get("/learning_diary", response_model=list[LearningDiaryResponse])
 def get_learning_diaries(
-    subject_id: Optional[int] = None,
+    subject_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -478,9 +487,9 @@ def create_progress(
     return db_progress
 
 
-@router.get("/progress", response_model=List[ProgressTrackingResponse])
+@router.get("/progress", response_model=list[ProgressTrackingResponse])
 def get_progress(
-    subject_id: Optional[int] = None,
+    subject_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -522,8 +531,8 @@ class ReviewResponse(BaseModel):
     topic: str
     mastery_level: int
     retrievability: float
-    next_review: Optional[datetime] = None
-    last_review: Optional[datetime] = None
+    next_review: datetime | None = None
+    last_review: datetime | None = None
 
 
 @router.post("/progress/{progress_id}/review", response_model=ReviewResponse)
@@ -561,14 +570,14 @@ def review_progress(
     )
 
 
-@router.get("/progress/due", response_model=List[ProgressTrackingResponse])
+@router.get("/progress/due", response_model=list[ProgressTrackingResponse])
 def get_due_reviews(
-    subject_id: Optional[int] = None,
+    subject_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """Get topics that are due for review (next_review <= now)."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     query = db.query(ProgressTracking).filter(
         ProgressTracking.user_id == current_user.id,
         ProgressTracking.next_review <= now,
@@ -580,12 +589,12 @@ def get_due_reviews(
 
 # Settings endpoints
 class SettingsUpdate(BaseModel):
-    default_provider: Optional[str] = None
-    api_key: Optional[str] = None
+    default_provider: str | None = None
+    api_key: str | None = None
 
 
 class SettingsResponse(BaseModel):
-    default_provider: Optional[str] = None
+    default_provider: str | None = None
 
 
 @router.get("/settings", response_model=SettingsResponse)

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1,12 +1,13 @@
+
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from pydantic import BaseModel, Field
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
-from pydantic import BaseModel, Field
-from typing import Optional
+
+from backend.core.security import create_access_token, decode_access_token, get_password_hash, verify_password
 from backend.db.database import get_db
-from backend.core.security import verify_password, get_password_hash, create_access_token, decode_access_token
 from backend.models.models import Tenant, User
 
 router = APIRouter()
@@ -18,7 +19,7 @@ limiter = Limiter(key_func=get_remote_address)
 class UserCreate(BaseModel):
     username: str = Field(..., min_length=3, max_length=50, pattern=r'^[a-zA-Z0-9_-]+$')
     password: str = Field(..., min_length=8, max_length=128)
-    tenant_name: Optional[str] = "default"
+    tenant_name: str | None = "default"
 
 
 class UserResponse(BaseModel):
@@ -36,8 +37,8 @@ class Token(BaseModel):
 
 
 class TokenData(BaseModel):
-    user_id: Optional[int] = None
-    username: Optional[str] = None
+    user_id: int | None = None
+    username: str | None = None
 
 
 def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> User:

--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -1,13 +1,15 @@
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
-from typing import Optional, List
-from datetime import datetime, timezone
-from backend.db.database import get_db
+from sqlalchemy.orm import Session
+
 from backend.api.routes.auth import get_current_user
-from backend.models.models import User, Session as SessionModel, ChatMessage, TeacherPersona, LearnerProfile, Subject
-from backend.services.learning_engine import learning_engine
 from backend.core.security import decrypt_api_key
+from backend.db.database import get_db
+from backend.models.models import ChatMessage, LearnerProfile, Subject, TeacherPersona, User
+from backend.models.models import Session as SessionModel
+from backend.services.learning_engine import learning_engine
 
 router = APIRouter()
 
@@ -20,9 +22,9 @@ class ChatRequest(BaseModel):
 class ChatResponse(BaseModel):
     type: str  # text, tool_request, choice
     reply: str
-    choices: Optional[List[str]] = None
-    emotion: Optional[dict] = None
-    relationship_stage: Optional[str] = None
+    choices: list[str] | None = None
+    emotion: dict | None = None
+    relationship_stage: str | None = None
 
 
 class ToolConfirmRequest(BaseModel):
@@ -114,7 +116,7 @@ async def send_message(
 
     if not db_session:
         # Auto-start a new session
-        start_result = await start_learning(subject_id, db, current_user)
+        await start_learning(subject_id, db, current_user)
         # Get the newly created session
         db_session = db.query(SessionModel).filter(
             SessionModel.subject_id == subject_id,
@@ -200,7 +202,7 @@ async def end_session(
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    session.ended_at = datetime.now(timezone.utc)
+    session.ended_at = datetime.now(UTC)
     db.commit()
 
     return {"message": "Session ended"}
@@ -238,7 +240,7 @@ async def get_history(
 # List user's sessions
 @router.get("/sessions")
 async def list_sessions(
-    subject_id: Optional[int] = None,
+    subject_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):

--- a/backend/api/routes/save.py
+++ b/backend/api/routes/save.py
@@ -1,15 +1,17 @@
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
-from pydantic import BaseModel, Field
-from typing import Optional, List
-from datetime import datetime
-from pathlib import Path
 import json
 import os
-from backend.db.database import get_db
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
 from backend.api.routes.auth import get_current_user
-from backend.models.models import User, Save, Session as SessionModel, ChatMessage, Subject, TeacherPersona, LearnerProfile
 from backend.core.config import get_settings
+from backend.db.database import get_db
+from backend.models.models import ChatMessage, Save, Subject, User
+from backend.models.models import Session as SessionModel
 
 router = APIRouter()
 settings = get_settings()
@@ -18,7 +20,7 @@ settings = get_settings()
 class SaveCreate(BaseModel):
     subject_id: int
     save_name: str = Field(..., max_length=100, pattern=r'^[a-zA-Z0-9_\-\u4e00-\u9fff]+$')
-    session_id: Optional[int] = None
+    session_id: int | None = None
 
 
 def _verify_save_path(file_path: str, user_id: int) -> None:
@@ -115,9 +117,9 @@ async def create_save(
 
 
 # Get saves list
-@router.get("/save", response_model=List[SaveResponse])
+@router.get("/save", response_model=list[SaveResponse])
 async def get_saves(
-    subject_id: Optional[int] = None,
+    subject_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -147,7 +149,7 @@ async def get_save(
     if not os.path.exists(save.file_path):
         raise HTTPException(status_code=404, detail="Save file not found")
 
-    with open(save.file_path, 'r', encoding='utf-8') as f:
+    with open(save.file_path, encoding='utf-8') as f:
         save_data = json.load(f)
 
     return {

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,7 +1,7 @@
 import warnings
-from pydantic_settings import BaseSettings
 from functools import lru_cache
-from typing import Optional
+
+from pydantic_settings import BaseSettings
 
 _DEFAULT_SECRET = "your-secret-key-change-in-production"
 

--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta, timezone
-from typing import Optional
+from datetime import UTC, datetime, timedelta
+
 from jose import JWTError, jwt
 from passlib.context import CryptContext
+
 from backend.core.config import get_settings
 
 settings = get_settings()
@@ -16,18 +17,18 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.now(timezone.utc) + expires_delta
+        expire = datetime.now(UTC) + expires_delta
     else:
-        expire = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_expire_minutes)
+        expire = datetime.now(UTC) + timedelta(minutes=settings.access_token_expire_minutes)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
     return encoded_jwt
 
 
-def decode_access_token(token: str) -> Optional[dict]:
+def decode_access_token(token: str) -> dict | None:
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
         return payload
@@ -37,8 +38,9 @@ def decode_access_token(token: str) -> Optional[dict]:
 
 def encrypt_api_key(api_key: str) -> str:
     """Encrypt API key usingFernet symmetric encryption"""
-    from cryptography.fernet import Fernet
     import base64
+
+    from cryptography.fernet import Fernet
 
     # Generate key from secret_key (must be 32 bytes for Fernet)
     key = base64.urlsafe_b64encode(settings.secret_key.ljust(32)[:32].encode())
@@ -46,10 +48,11 @@ def encrypt_api_key(api_key: str) -> str:
     return f.encrypt(api_key.encode()).decode()
 
 
-def decrypt_api_key(encrypted_key: str) -> Optional[str]:
+def decrypt_api_key(encrypted_key: str) -> str | None:
     """Decrypt API key"""
-    from cryptography.fernet import Fernet
     import base64
+
+    from cryptography.fernet import Fernet
 
     try:
         key = base64.urlsafe_b64encode(settings.secret_key.ljust(32)[:32].encode())

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
+
 from backend.core.config import get_settings
 
 settings = get_settings()
@@ -19,5 +19,4 @@ def get_db():
 
 
 def init_db():
-    from backend import models
     Base.metadata.create_all(bind=engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,8 +3,9 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
 from backend.core.config import get_settings
 from backend.db.database import init_db
 
@@ -66,6 +67,7 @@ async def root():
 @app.get("/health")
 async def health_check():
     from sqlalchemy import text
+
     from backend.db.database import SessionLocal
     from backend.services.memory import memory_service
 
@@ -93,7 +95,7 @@ async def health_check():
 
 
 # Import and include routers
-from backend.api.routes import auth, archive, learning, save
+from backend.api.routes import archive, auth, learning, save  # noqa: E402
 
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(archive.router, prefix="/api", tags=["archive"])

--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -1,6 +1,7 @@
-from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, JSON
+from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+
 from backend.db.database import Base
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,4 +8,4 @@ line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM"]
-ignore = ["E501"]
+ignore = ["E501", "B008", "E711", "E712"]

--- a/backend/services/dynamic_analyzer.py
+++ b/backend/services/dynamic_analyzer.py
@@ -8,7 +8,6 @@ Supports 8 education-specific emotion categories with two analysis modes:
 import json
 import logging
 import re
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +161,7 @@ class DynamicAnalyzer:
     # ------------------------------------------------------------------
     async def _llm_analyze(
         self, text: str, user_api_key: str, provider: str
-    ) -> Optional[dict]:
+    ) -> dict | None:
         """Call LLM for structured emotion classification."""
         from backend.services.llm.adapter import get_llm_adapter
 

--- a/backend/services/knowledge_graph.py
+++ b/backend/services/knowledge_graph.py
@@ -7,8 +7,8 @@ structured concept relationships and temporal knowledge evolution.
 """
 
 import logging
-from datetime import datetime, timezone
-from typing import Any, Optional
+from datetime import UTC, datetime
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class KnowledgeGraphService:
         self._uri = "bolt://localhost:7687"
         self._user = "neo4j"
         self._password = "socratic_learning"
-        self._graphiti: Optional[Any] = None
+        self._graphiti: Any | None = None
         self._initialized = False
 
     def configure(
@@ -92,7 +92,7 @@ class KnowledgeGraphService:
             return {"status": "disabled"}
 
         group_id = self._group_id(user_id, subject_id)
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         try:
             # Combine student+teacher into one episode to halve LLM calls
@@ -174,8 +174,8 @@ class KnowledgeGraphService:
         group_id = self._group_id(user_id, subject_id)
 
         try:
-            from graphiti_core.nodes import EntityNode
             from graphiti_core.edges import EntityEdge
+            from graphiti_core.nodes import EntityNode
 
             nodes = await EntityNode.get_by_group_ids(
                 self._graphiti.driver, group_ids=[group_id], limit=limit

--- a/backend/services/learning_engine.py
+++ b/backend/services/learning_engine.py
@@ -3,22 +3,24 @@
 import json
 import logging
 import re
-from typing import List, Optional
 
 from sqlalchemy import func as sqlfunc
-from backend.services.llm.adapter import get_llm_adapter
-from backend.services.memory import memory_service
-from backend.services.dynamic_analyzer import DynamicAnalyzer
-from backend.services.knowledge_graph import knowledge_graph_service
+
 from backend.db.database import SessionLocal
 from backend.models.models import (
-    Session as SessionModel,
-    TeacherPersona,
-    LearnerProfile,
     ChatMessage,
-    RelationshipStageRecord,
+    LearnerProfile,
     ProgressTracking,
+    RelationshipStageRecord,
+    TeacherPersona,
 )
+from backend.models.models import (
+    Session as SessionModel,
+)
+from backend.services.dynamic_analyzer import DynamicAnalyzer
+from backend.services.knowledge_graph import knowledge_graph_service
+from backend.services.llm.adapter import get_llm_adapter
+from backend.services.memory import memory_service
 
 logger = logging.getLogger(__name__)
 
@@ -102,9 +104,9 @@ class LearningEngine:
         self,
         teacher_persona: TeacherPersona,
         relationship_stage: str,
-        learner_profile: Optional[LearnerProfile] = None,
-        retrieved_memories: List[dict] = None,
-        prev_emotion: Optional[dict] = None,
+        learner_profile: LearnerProfile | None = None,
+        retrieved_memories: list[dict] = None,
+        prev_emotion: dict | None = None,
         mastery_level: int = 50,
         knowledge_context: str = "",
     ) -> str:
@@ -146,9 +148,9 @@ class LearningEngine:
     def _build_dynamic_layer(
         self,
         relationship_stage: str,
-        learner_profile: Optional[LearnerProfile],
-        retrieved_memories: Optional[List[dict]],
-        prev_emotion: Optional[dict],
+        learner_profile: LearnerProfile | None,
+        retrieved_memories: list[dict] | None,
+        prev_emotion: dict | None,
         mastery_level: int = 50,
         knowledge_context: str = "",
     ) -> str:
@@ -194,7 +196,7 @@ class LearningEngine:
 
         return "\n\n".join(parts)
 
-    def parse_tool_request(self, response: str) -> Optional[dict]:
+    def parse_tool_request(self, response: str) -> dict | None:
         """Parse tool request from LLM response"""
         # Try JSON format
         try:
@@ -384,7 +386,7 @@ class LearningEngine:
                 "used_memory_ids": [user_memory_id, teacher_memory_id]
             }
 
-        except Exception as e:
+        except Exception:
             logger.error("Message processing failed", exc_info=True)
             return {
                 "type": "error",

--- a/backend/services/llm/adapter.py
+++ b/backend/services/llm/adapter.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,7 @@ class ClaudeAdapter(LLMAdapter):
     async def chat(self, messages: list, system_prompt: str, user_api_key: str = None) -> str:
         """Send chat request to Claude API"""
         import httpx
+
         from backend.core.config import get_settings
 
         settings = get_settings()
@@ -94,6 +95,7 @@ class OpenAIAdapter(LLMAdapter):
     async def chat(self, messages: list, system_prompt: str, user_api_key: str = None) -> str:
         """Send chat request to OpenAI API"""
         import httpx
+
         from backend.core.config import get_settings
 
         settings = get_settings()
@@ -197,25 +199,24 @@ class LocalAdapter(LLMAdapter):
                 "content": msg.get("content", "")
             })
 
-        async with httpx.AsyncClient() as client:
-            async with client.stream(
-                "POST",
-                f"{self.base_url}/api/chat",
-                json={
-                    "model": self.model,
-                    "messages": local_messages,
-                    "stream": True
-                }
-            ) as response:
-                async for line in response.aiter_lines():
-                    if line:
-                        import json
-                        try:
-                            data = json.loads(line)
-                            if "message" in data:
-                                yield data["message"].get("content", "")
-                        except:
-                            pass
+        async with httpx.AsyncClient() as client, client.stream(
+            "POST",
+            f"{self.base_url}/api/chat",
+            json={
+                "model": self.model,
+                "messages": local_messages,
+                "stream": True
+            }
+        ) as response:
+            async for line in response.aiter_lines():
+                if line:
+                    import json
+                    try:
+                        data = json.loads(line)
+                        if "message" in data:
+                            yield data["message"].get("content", "")
+                    except Exception:
+                        pass
 
 
 def get_llm_adapter(provider: str = "claude") -> LLMAdapter:

--- a/backend/services/memory.py
+++ b/backend/services/memory.py
@@ -1,8 +1,8 @@
 """Memory service using ChromaDB for vector storage"""
 
 import os
-from typing import List, Optional
 import uuid
+
 import chromadb
 from chromadb.config import Settings
 
@@ -43,7 +43,7 @@ class MemoryService:
 
         return memory_id
 
-    def retrieve(self, session_id: str, query: str, top_k: int = 3) -> List[dict]:
+    def retrieve(self, session_id: str, query: str, top_k: int = 3) -> list[dict]:
         """Retrieve relevant memories based on query"""
         collection = self.get_or_create_collection(session_id)
 
@@ -70,10 +70,10 @@ class MemoryService:
 
     def clear_session(self, session_id: str):
         """Clear all memories for a session"""
-        try:
+        import contextlib
+
+        with contextlib.suppress(Exception):
             self.client.delete_collection(name=f"{self.collection_name}_{session_id}")
-        except:
-            pass
 
     def get_memory_count(self, session_id: str) -> int:
         """Get count of memories in session"""

--- a/backend/services/spaced_repetition.py
+++ b/backend/services/spaced_repetition.py
@@ -4,11 +4,9 @@ Wraps py-fsrs to provide topic-level review scheduling for the learning system.
 Each ProgressTracking record stores an FSRS Card state in its `fsrs_state` JSON column.
 """
 
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import UTC, datetime
 
 from fsrs import Card, Rating, Scheduler, State
-
 
 # Shared scheduler instance with sensible defaults for educational context
 _scheduler = Scheduler(
@@ -30,7 +28,7 @@ def new_card() -> dict:
     return Card().to_dict()
 
 
-def review(fsrs_state: Optional[dict], rating_int: int) -> dict:
+def review(fsrs_state: dict | None, rating_int: int) -> dict:
     """
     Review a topic and return updated state.
 
@@ -45,13 +43,10 @@ def review(fsrs_state: Optional[dict], rating_int: int) -> dict:
         raise ValueError(f"rating must be 1-4, got {rating_int}")
 
     rating = RATING_MAP[rating_int]
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     # Restore or create card
-    if fsrs_state:
-        card = Card.from_dict(fsrs_state)
-    else:
-        card = Card()
+    card = Card.from_dict(fsrs_state) if fsrs_state else Card()
 
     # Perform the review
     card, _review_log = _scheduler.review_card(card, rating, review_datetime=now)
@@ -74,7 +69,7 @@ def review(fsrs_state: Optional[dict], rating_int: int) -> dict:
 def get_retrievability(fsrs_state: dict) -> float:
     """Get current recall probability for a card."""
     card = Card.from_dict(fsrs_state)
-    return _scheduler.get_card_retrievability(card, datetime.now(timezone.utc))
+    return _scheduler.get_card_retrievability(card, datetime.now(UTC))
 
 
 def _compute_mastery(card: Card, retrievability: float) -> int:

--- a/backend/tests/test_fsrs.py
+++ b/backend/tests/test_fsrs.py
@@ -1,7 +1,8 @@
 """Tests for FSRS spaced repetition service."""
 
 import pytest
-from backend.services.spaced_repetition import new_card, review, get_retrievability
+
+from backend.services.spaced_repetition import get_retrievability, new_card, review
 
 
 class TestNewCard:


### PR DESCRIPTION
## 变更概述
一次性清理所有 Ruff 存量 lint 错误，使 CI lint job 通过。

## 改动
- 19 个文件的 import 排序、deprecated typing、unused imports（自动修复）
- bare except → Exception, try-except-pass → contextlib.suppress（手动）
- unused variable `start_result` 移除
- if-else → ternary（spaced_repetition.py）
- pyproject.toml：ignore B008 (FastAPI Depends), E711/E712 (SQLAlchemy)
- main.py router import: noqa E402

## 自查
- [x] `ruff check backend/` All checks passed