### PR TITLE
fix: resolve 4 TypeScript errors in Learning.vue

### DIFF
--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -82,13 +82,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, nextTick, watch } from 'vue'
+import { ref, onMounted, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
-import DialogBox from '@/components/galgame/DialogBox.vue'
 import ChoicePanel from '@/components/galgame/ChoicePanel.vue'
-import CharacterDisplay from '@/components/galgame/CharacterDisplay.vue'
 import EmotionIndicator from '@/components/galgame/EmotionIndicator.vue'
 import SaveLoad from '@/components/galgame/SaveLoad.vue'
 import ToolConfirmDialog from '@/components/galgame/ToolConfirmDialog.vue'
@@ -121,7 +119,7 @@ const displayedText = ref('')
 const currentChoices = ref<string[]>([])
 const showToolConfirm = ref(false)
 const showSaveLoad = ref(false)
-const sessionId = ref<number | null>(null)
+const sessionId = ref<number | undefined>(undefined)
 const currentEmotion = ref('')
 const toolRequest = ref({ tool: '', query: '', reason: '' })
 const dialogArea = ref<HTMLElement | null>(null)


### PR DESCRIPTION
## 变更概述
修复 vue-tsc 升级到 ^2.2.0 后暴露的 4 个 TS 错误。

## 改动
- `Learning.vue`：移除 3 个 unused imports（watch, DialogBox, CharacterDisplay）
- `Learning.vue`：sessionId 类型 `number | null` → `number | undefined`（匹配 SaveLoad prop）

## 自查
- [x] vue-tsc 编译通过（CI frontend-build job）