### PR TITLE
feat: replace pip with uv for faster installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - uses: astral-sh/setup-uv@v3
       - name: Install dependencies
         run: |
           cd backend
-          pip install -r requirements-dev.txt
+          uv pip install -r requirements-dev.txt --system
       - name: Run tests
         run: |
           cd backend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,10 @@ WebGAL/            # Reserved for WebGAL integration (empty)
 cd frontend && npm install && npm run dev    # Dev server on :5173
 cd frontend && npm run build                 # Production build
 
-# Backend
-cd backend && pip install -r requirements.txt                   # Production deps
-cd backend && pip install -r requirements-dev.txt               # Dev + test deps
+# Backend (uv recommended for speed, pip also works)
+pip install uv                                                  # One-time install
+cd backend && uv pip install -r requirements.txt --system       # Production deps
+cd backend && uv pip install -r requirements-dev.txt --system   # Dev + test deps
 cd backend && uvicorn main:app --reload --port 8000
 
 # Tests (requires requirements-dev.txt)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install uv && uv pip install --no-cache-dir --system -r requirements.txt
 
 COPY . ./backend/
 


### PR DESCRIPTION
## 关联 Issue
Closes #83

## 变更概述
用 uv（Astral 出品，Rust 实现）替代 pip，加速 CI 和 Docker 构建中的依赖安装。

## 改动清单
- `.github/workflows/ci.yml`：添加 `astral-sh/setup-uv@v3`，`pip install` → `uv pip install --system`
- `backend/Dockerfile`：`pip install uv` 后用 `uv pip install` 安装依赖
- `CLAUDE.md`：本地开发命令更新为推荐 uv

## 自查
- [x] `--system` 标志让 uv 安装到系统 Python（CI 和 Docker 都需要）
- [x] uv 100% pip 兼容，requirements.txt 格式不变
- [x] pip 仍可用作 fallback（CLAUDE.md 注明）

## Reviewer 关注点
@reviewer 请看：Dockerfile 中先 pip install uv 再 uv install 是否可以改为 COPY --from 多阶段安装 uv binary