### PR TITLE
fix: remove chromadb healthcheck (image has no tools)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       postgres:
         condition: service_healthy
       chromadb:
-        condition: service_healthy
+        condition: service_started
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 10s
@@ -61,11 +61,8 @@ services:
       - chroma_data:/chroma/chroma
     environment:
       ANONYMIZED_TELEMETRY: "false"
-    healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/heartbeat')"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
+    # No healthcheck — chromadb/chroma image has no python/curl/wget
+    # backend start_period gives chromadb enough time to initialize
     restart: unless-stopped
 
   neo4j:


### PR DESCRIPTION
## 关联 Issue
Closes #86

## 变更概述
chromadb/chroma:latest 极简镜像内无 python/curl/wget/nc，任何 healthcheck 命令都会失败导致部署卡死。移除 healthcheck，改用 service_started。

## 改动
- `docker-compose.yml`：删除 chromadb healthcheck 块，backend depends 改为 `service_started`

## 自查
- [x] backend start_period: 15s 给 chromadb 足够启动时间
- [x] /health 端点仍检测 chromadb 连通性（运行时监控不受影响）