### PR TITLE
feat: parseApiError utility for user-friendly error messages

### DIFF
--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -1,0 +1,55 @@
+/**
+ * Parse API error responses into user-friendly Chinese messages.
+ */
+export function parseApiError(error: any): string {
+  const data = error.response?.data
+
+  // Pydantic 422 validation errors
+  if (Array.isArray(data?.detail)) {
+    return data.detail.map((e: any) => {
+      const field = e.loc?.[e.loc.length - 1] || ''
+      const fieldNames: Record<string, string> = {
+        username: '用户名',
+        password: '密码',
+        name: '名称',
+        message: '消息',
+        save_name: '存档名',
+        email: '邮箱',
+      }
+      const name = fieldNames[field] || field
+
+      const messages: Record<string, string> = {
+        string_too_short: `${name}至少需要 ${e.ctx?.min_length} 个字符`,
+        string_too_long: `${name}不能超过 ${e.ctx?.max_length} 个字符`,
+        string_pattern_mismatch: `${name}只能包含字母、数字、下划线和横杠`,
+        value_error: `${name}格式不正确`,
+      }
+      return messages[e.type] || e.msg
+    }).join('；')
+  }
+
+  // String error from backend
+  if (typeof data?.detail === 'string') {
+    const friendlyMessages: Record<string, string> = {
+      'Username already registered': '该用户名已被注册',
+      'Incorrect username or password': '用户名或密码错误',
+      'Could not validate credentials': '登录已过期，请重新登录',
+      'Subject not found': '科目不存在',
+      'Character not found': '角色不存在',
+      'Teacher persona not found': '教师人格不存在',
+      'Session not found': '会话不存在',
+      'Save not found': '存档不存在',
+      'Progress not found': '进度不存在',
+      'Access denied': '访问被拒绝',
+    }
+    return friendlyMessages[data.detail] || data.detail
+  }
+
+  // Network error
+  if (!error.response) return '网络连接失败，请检查网络'
+
+  // Rate limit
+  if (error.response?.status === 429) return '操作太频繁，请稍后再试'
+
+  return '操作失败，请重试'
+}

--- a/frontend/src/views/Character.vue
+++ b/frontend/src/views/Character.vue
@@ -5,6 +5,8 @@
       <h1>角色设定</h1>
     </header>
 
+    <div v-if="errorMessage" class="error-toast">{{ errorMessage }}</div>
+
     <main class="main">
       <!-- 角色列表 -->
       <section class="section">
@@ -179,9 +181,16 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
+import { parseApiError } from '@/utils/error'
 
 const router = useRouter()
 const authStore = useAuthStore()
+const errorMessage = ref('')
+
+const showError = (e: any) => {
+  errorMessage.value = parseApiError(e)
+  setTimeout(() => { errorMessage.value = '' }, 5000)
+}
 
 interface Character {
   id: number
@@ -247,7 +256,7 @@ const fetchCharacters = async () => {
     const res = await axios.get('/api/character', { headers: headers() })
     characters.value = res.data
   } catch (error) {
-    console.error('Failed to fetch characters:', error)
+    showError(error)
   }
 }
 
@@ -256,7 +265,7 @@ const fetchTeacherPersonas = async (characterId: number) => {
     const res = await axios.get(`/api/teacher_persona?character_id=${characterId}`, { headers: headers() })
     teacherPersonas.value = res.data
   } catch (error) {
-    console.error('Failed to fetch personas:', error)
+    showError(error)
   }
 }
 
@@ -265,7 +274,7 @@ const fetchSubjects = async (characterId: number) => {
     const res = await axios.get(`/api/subjects?character_id=${characterId}`, { headers: headers() })
     subjects.value = res.data
   } catch (error) {
-    console.error('Failed to fetch subjects:', error)
+    showError(error)
   }
 }
 
@@ -309,7 +318,7 @@ const saveCharacter = async () => {
     resetCharacterForm()
     fetchCharacters()
   } catch (error) {
-    console.error('Failed to save character:', error)
+    showError(error)
   }
 }
 
@@ -324,7 +333,7 @@ const deleteCharacter = async (id: number) => {
     }
     fetchCharacters()
   } catch (error) {
-    console.error('Failed to delete character:', error)
+    showError(error)
   }
 }
 
@@ -374,7 +383,7 @@ const savePersona = async () => {
     resetPersonaForm()
     fetchTeacherPersonas(selectedCharacter.value.id)
   } catch (error) {
-    console.error('Failed to save persona:', error)
+    showError(error)
   }
 }
 
@@ -386,7 +395,7 @@ const deletePersona = async (id: number) => {
       fetchTeacherPersonas(selectedCharacter.value.id)
     }
   } catch (error) {
-    console.error('Failed to delete persona:', error)
+    showError(error)
   }
 }
 
@@ -397,7 +406,7 @@ const activatePersona = async (personaId: number) => {
       fetchTeacherPersonas(selectedCharacter.value.id)
     }
   } catch (error) {
-    console.error('Failed to activate persona:', error)
+    showError(error)
   }
 }
 
@@ -441,7 +450,7 @@ const saveSubject = async () => {
     resetSubjectForm()
     fetchSubjects(selectedCharacter.value.id)
   } catch (error) {
-    console.error('Failed to save subject:', error)
+    showError(error)
   }
 }
 
@@ -453,7 +462,7 @@ const deleteSubject = async (id: number) => {
       fetchSubjects(selectedCharacter.value.id)
     }
   } catch (error) {
-    console.error('Failed to delete subject:', error)
+    showError(error)
   }
 }
 
@@ -731,5 +740,18 @@ onMounted(() => {
 
 .dialog-actions button.primary:hover {
   background: #5a9a5a;
+}
+
+.error-toast {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(215, 58, 74, 0.9);
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 8px;
+  z-index: 2000;
+  font-size: 14px;
 }
 </style>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -38,6 +38,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { parseApiError } from '@/utils/error'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -45,24 +46,32 @@ const authStore = useAuthStore()
 const username = ref('')
 const password = ref('')
 const error = ref('')
+const isLoading = ref(false)
 
 const handleLogin = async () => {
   error.value = ''
+  isLoading.value = true
   try {
     await authStore.login(username.value, password.value)
     router.push('/home')
   } catch (e: any) {
-    error.value = e.response?.data?.detail || '登录失败'
+    error.value = parseApiError(e)
+  } finally {
+    isLoading.value = false
   }
 }
 
 const handleRegister = async () => {
   error.value = ''
+  isLoading.value = true
   try {
     await authStore.register(username.value, password.value)
+    error.value = ''
     alert('注册成功，请登录')
   } catch (e: any) {
-    error.value = e.response?.data?.detail || '注册失败'
+    error.value = parseApiError(e)
+  } finally {
+    isLoading.value = false
   }
 }
 </script>


### PR DESCRIPTION
## 关联 Issue
Part of #104（第 1 层：立即可做）

## 变更概述
新增全局错误解析工具函数，将原始 API 错误转为中文友好提示。集成到 Login 和 Character 页面。

## 改动清单
- `frontend/src/utils/error.ts`：新文件，parseApiError 函数
- `frontend/src/views/Login.vue`：使用 parseApiError + 添加 loading 状态
- `frontend/src/views/Character.vue`：10 个 console.error 替换为可见错误 toast

## 自查
- [x] Pydantic 422 错误转中文（如"密码至少需要 8 个字符"）
- [x] 后端字符串错误有友好映射
- [x] 网络错误和 429 限流有专门提示
- [x] Character 错误 toast 5 秒后自动消失