### PR TITLE
feat: Galgame four-layer layout for Learning page

### DIFF
--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -302,9 +302,12 @@ const handleLoadSave = (saveData: any) => {
   }
   if (saveData.chat_history) {
     messages.value = saveData.chat_history
+    const lastTeacher = [...messages.value].reverse().find(m => m.sender_type === 'teacher')
+    if (lastTeacher) {
+      lastTeacherReply.value = lastTeacher.content
+    }
   }
   showSaveLoad.value = false
-  scrollToBottom()
   renderMermaid()
 }
 


### PR DESCRIPTION
## 关联 Issue
Closes #91 (总规划 #93/#100 的 Phase 1 F1)

## 变更概述
将 Learning.vue 从聊天气泡 UI 重构为 Galgame 四层固定布局。

## 布局结构
```
┌─────────────────────────────────┐
│ Layer 0: 场景背景（CSS 渐变）    │ z-index: 0
│                                 │
│    ┌──────────┐                 │
│    │ Layer 1:  │                 │ z-index: 1
│    │ 角色占位   │                 │
│    └──────────┘                 │
│                                 │
│ ┌─────────────────────────────┐ │
│ │ Layer 2: 对话框 + 输入       │ │ z-index: 2
│ └─────────────────────────────┘ │
│ [Layer 3: HUD 栏]               │ z-index: 3
└─────────────────────────────────┘
```

## 关键改动
- 移除滚动消息列表，对话框只显示最新教师回复
- messages 数组保留供后续 Backlog (#98) 使用
- lastTeacherReply 在页面加载时从历史恢复
- greeting 从 start_learning API 获取（Phase 0 #95 已支持）
- 移动端隐藏角色层，对话框占更多屏幕

## 后续 Issue 预留
- #96: DialogBox 组件集成替代 dialog-box-wrapper
- #98: HUD 栏完善 + Backlog 面板
- #92: 角色立绘替代 placeholder
- #97: 点击推进

## 自查
- [x] 所有学习功能可用（对话、打字机、选择、工具确认、存档）
- [x] messages 数组完整保留
- [x] 移动端适配（character-layer hidden）
- [x] 不修改后端

## Reviewer 关注点
@reviewer 请看：
1. dialog-box-wrapper 的 max-height 200px 是否够显示长回复
2. 角色占位符的位置（bottom: 240px）是否与对话框有视觉重叠
3. greeting 和 lastTeacherReply 的优先级是否正确