### PR TITLE
feat: CharacterDisplay emotion-driven sprites + expression

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -19,6 +19,7 @@
   /* Emotion */
   --emotion-positive: #4adf6a;
   --emotion-negative: #df4a4a;
+  --emotion-thinking: #60a5fa;
   --emotion-neutral: #888888;
 
   /* Border */

--- a/frontend/src/components/galgame/CharacterDisplay.vue
+++ b/frontend/src/components/galgame/CharacterDisplay.vue
@@ -34,6 +34,9 @@ const spriteError = ref(false)
 
 const currentExpression = computed(() => props.expression || 'default')
 
+// Reset error when expression changes so new sprite gets a chance to load
+watch(currentExpression, () => { spriteError.value = false })
+
 const spriteUrl = computed(() => {
   if (spriteError.value) return null
   if (!props.sprites) return null
@@ -125,7 +128,7 @@ const expressionClass = computed(() => `expr-${currentExpression.value}`)
 }
 
 .placeholder-avatar.expr-thinking {
-  border-color: #60a5fa;
+  border-color: var(--emotion-thinking);
   box-shadow: 0 0 30px rgba(96, 165, 250, 0.2);
 }
 

--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -356,6 +356,10 @@ const sendMessage = async () => {
 
     // 处理不同响应类型
     if (data.type === 'tool_request') {
+      // Update expression
+      if (data.expression_hint) {
+        currentExpression.value = data.expression_hint
+      }
       // Show teacher reply first (strip tool tags)
       if (data.reply) {
         const cleanReply = data.reply.replace(/<tool>[\s\S]*?<\/tool>/g, '').trim()


### PR DESCRIPTION
## 关联 Issue
Closes #92 (Phase 2 F9/角色立绘)

## 变更概述
增强 CharacterDisplay 组件支持情绪驱动的立绘切换，集成到 Learning.vue。

## 改动清单
- `CharacterDisplay.vue`：重构——接受 sprites dict + expression prop，Vue Transition 交叉淡入切换，placeholder 表情视觉反馈
- `Learning.vue`：集成 CharacterDisplay，读取 API `expression_hint`，等待时设为 thinking

## 表情系统
```
后端 emotion_type → EXPRESSION_MAP → expression_hint → 前端 CharacterDisplay
  curiosity      →    thinking     →   thinking      → 蓝色边框/思考立绘
  excitement     →    happy        →   happy         → 绿色边框/开心立绘
  frustration    →    concerned    →   concerned     → 红色边框/关切立绘
  neutral        →    default      →   default       → 金色边框/默认立绘
```

## 自查
- [x] 无 sprites 时显示 placeholder + 表情 emoji + 颜色变化
- [x] sprites 加载失败时 graceful fallback
- [x] WAITING 模式自动切 thinking 表情
- [x] choice/normal 响应都更新 expression
- [x] 移除 Learning.vue 旧 placeholder CSS

## Reviewer 关注点
@reviewer 请看：
1. characterSprites ref 当前始终 undefined（等 #109 上传 API），placeholder 路径是否正确
2. sprites 交叉淡入是否需要 jump 动画（参考 paper2galgame 的 animate-jump-once）