### PR TITLE
fix: 4 frontend runtime bugs (#117)

### DIFF
--- a/frontend/src/views/Character.vue
+++ b/frontend/src/views/Character.vue
@@ -310,6 +310,7 @@ const uploadSprites = async () => {
     // Update in characters list
     const idx = characters.value.findIndex(c => c.id === spriteCharacter.value?.id)
     if (idx >= 0) characters.value[idx].sprites = res.data.sprites
+    if (spriteFileInput.value) spriteFileInput.value.value = ''
     showSpriteDialog.value = false
   } catch (error) {
     showError(error)
@@ -374,8 +375,8 @@ const generatePersona = async () => {
     const res = await axios.post('/api/persona/generate', {
       description: aiDescription.value.trim(),
     }, { headers: headers() })
-    personaForm.value.system_prompt_template = res.data.system_prompt_template
-    personaForm.value.traitsInput = res.data.traits.join(', ')
+    personaForm.value.system_prompt_template = res.data.system_prompt_template || ''
+    personaForm.value.traitsInput = (res.data.traits || []).join(', ')
     if (!personaForm.value.name) {
       personaForm.value.name = res.data.name_suggestion
     }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -53,6 +53,7 @@
         </div>
       </section>
     </main>
+    <div v-if="errorMessage" class="error-toast">{{ errorMessage }}</div>
   </div>
 </template>
 
@@ -256,5 +257,18 @@ h2 {
   background: #4a8a4a;
   border-radius: 12px;
   font-size: 12px;
+}
+
+.error-toast {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(215, 58, 74, 0.9);
+  color: #fff;
+  padding: 10px 24px;
+  border-radius: 8px;
+  font-size: 14px;
+  z-index: 100;
 }
 </style>

--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -460,6 +460,11 @@ const handleLoadSave = (saveData: any) => {
   if (saveData.relationship_stage) {
     relationshipStage.value = saveData.relationship_stage
   }
+  if (saveData.expression) {
+    currentExpression.value = saveData.expression
+  } else {
+    currentExpression.value = 'default'
+  }
   if (saveData.chat_history) {
     messages.value = saveData.chat_history
     const lastTeacher = [...messages.value].reverse().find(m => m.sender_type === 'teacher')


### PR DESCRIPTION
## 关联 Issue
Closes #117

## 改动
| # | Bug | 修复 |
|---|-----|------|
| 1 🔴 | Home.vue errorMessage 定义但不渲染 | 加 error-toast 元素 + CSS |
| 2 🟡 | 读档不恢复角色表情 | handleLoadSave 加 expression 恢复 |
| 3 🔴 | AI 生成 traits 缺失时 crash | `(res.data.traits \|\| []).join()` |
| 4 🟡 | 立绘上传后 file input 不重置 | 上传成功后 `input.value = ''` |