### PR TITLE
feat: visual polish Phase A — blur, rounded, jump, mobile

### DIFF
--- a/frontend/src/components/galgame/CharacterDisplay.vue
+++ b/frontend/src/components/galgame/CharacterDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="character-display" :class="position">
+  <div class="character-display" :class="position" :key="jumpKey" :style="jumpKey > 0 ? { animation: 'jumpOnce 0.3s ease' } : {}">
     <Transition name="sprite-switch" mode="out-in">
       <img
         v-if="spriteUrl"
@@ -34,8 +34,13 @@ const spriteError = ref(false)
 
 const currentExpression = computed(() => props.expression || 'default')
 
-// Reset error when expression changes so new sprite gets a chance to load
-watch(currentExpression, () => { spriteError.value = false })
+const jumpKey = ref(0)
+
+// Reset error and trigger jump when expression changes
+watch(currentExpression, () => {
+  spriteError.value = false
+  jumpKey.value++
+})
 
 const spriteUrl = computed(() => {
   if (spriteError.value) return null
@@ -152,5 +157,11 @@ const expressionClass = computed(() => `expr-${currentExpression.value}`)
     height: 80px;
     font-size: 32px;
   }
+}
+
+@keyframes jumpOnce {
+  0% { transform: translateY(0); }
+  40% { transform: translateY(-15px); }
+  100% { transform: translateY(0); }
 }
 </style>

--- a/frontend/src/components/galgame/DialogBox.vue
+++ b/frontend/src/components/galgame/DialogBox.vue
@@ -105,9 +105,11 @@ const handleSend = () => {
 
 <style scoped>
 .dialog-box {
-  background: var(--bg-panel);
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border-accent);
-  border-radius: 4px;
+  border-radius: 12px;
   padding: 20px 24px;
   min-height: 160px;
   max-height: 240px;
@@ -140,7 +142,7 @@ const handleSend = () => {
 /* Dialog text */
 .dialog-text {
   color: var(--text-primary);
-  font-size: 17px;
+  font-size: 19px;
   line-height: 1.9;
   white-space: pre-wrap;
   margin-top: 4px;
@@ -260,7 +262,7 @@ const handleSend = () => {
     min-height: 140px;
   }
   .dialog-text {
-    font-size: 15px;
+    font-size: 16px;
   }
 }
 </style>

--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -645,7 +645,9 @@ onUnmounted(() => {
 /* Mobile */
 @media (max-width: 768px) {
   .character-layer {
-    display: none;
+    transform: translateX(-50%) scale(0.5);
+    bottom: 200px;
+    opacity: 0.7;
   }
   .dialog-layer {
     left: 2%;


### PR DESCRIPTION
## 关联 Issue
Part of #118 Phase A

## 5 项 CSS 快修
| # | 改动 | 效果 |
|---|------|------|
| A1 | 对话框半透明毛玻璃 | 透过场景背景，视觉层次感 |
| A2 | 圆角 4px → 12px | 更柔和，VN 风格 |
| A3 | 字号 17px → 19px | 对话更易读 |
| A4 | 角色逐句弹跳 | expression 变化触发 0.3s jump 动画 |
| A5 | 移动端角色缩小 | 不再隐藏，scale(0.5) + 半透明 |

## 自查
- [x] backdrop-filter 加 -webkit 前缀兼容 Safari
- [x] jump 动画通过 :key 绑定 jumpKey 触发
- [x] 移动端角色 opacity 0.7 不遮挡对话框