### PR TITLE
fix: setup.sh auto-build + always use --build flag

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -23,8 +23,8 @@ bash scripts/setup.sh
 ## 二、Docker 一键启动
 
 ```bash
-# 构建并启动所有服务
-docker compose up -d
+# 构建并启动所有服务（--build 确保使用最新代码）
+docker compose up -d --build
 
 # 查看启动状态
 docker compose ps

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -100,8 +100,18 @@ ENVEOF
 echo ""
 echo "✅ .env 已生成"
 echo ""
-echo "下一步："
-echo "  docker compose up -d"
-echo "  访问 ${CORS_ORIGIN}"
-echo "  LLM API Key 请在网页设置页配置"
+read -p "是否立即启动？(Y/n) " start
+if [[ "$start" != "n" && "$start" != "N" ]]; then
+    echo "正在构建并启动服务..."
+    docker compose up -d --build
+    echo ""
+    echo "✅ 服务已启动"
+    echo "  访问 ${CORS_ORIGIN}"
+    echo "  LLM API Key 请在网页设置页配置"
+else
+    echo "下一步："
+    echo "  docker compose up -d --build"
+    echo "  访问 ${CORS_ORIGIN}"
+    echo "  LLM API Key 请在网页设置页配置"
+fi
 echo ""


### PR DESCRIPTION
## 变更概述
防止 docker compose up 复用旧镜像导致代码更新不生效。

## 改动
- `scripts/setup.sh`：生成 .env 后询问是否立即启动，用 `--build` 确保重建
- `docs/DEPLOYMENT.md`：启动命令加 `--build`