### PR TITLE
feat: restore Galgame Home.vue + themed SaveLoad.vue

### DIFF
--- a/frontend/src/components/galgame/SaveLoad.vue
+++ b/frontend/src/components/galgame/SaveLoad.vue
@@ -24,6 +24,7 @@
         v-for="save in saves"
         :key="save.id"
         class="save-item"
+        :class="{ 'save-item-selected': selectedSave?.id === save.id }"
         @click="selectSave(save)"
       >
         <span class="save-name">{{ save.save_name }}</span>
@@ -43,25 +44,32 @@
       />
       <button
         v-if="mode === 'save' && newSaveName.trim()"
-        class="action-button save"
+        class="action-button action-save"
         @click="handleSave"
       >
         确认存档
       </button>
       <button
         v-if="selectedSave && mode === 'load'"
-        class="action-button load"
+        class="action-button action-load"
         @click="handleLoad"
       >
         确认读档
       </button>
     </div>
+
+    <!-- Toast 通知 -->
+    <Transition name="toast">
+      <div v-if="toast.show" class="toast" :class="toast.type">
+        {{ toast.message }}
+      </div>
+    </Transition>
   </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, reactive, onMounted } from 'vue'
 import axios from 'axios'
 import { parseApiError } from '@/utils/error'
 
@@ -79,6 +87,14 @@ const mode = ref<'save' | 'load'>('save')
 const saves = ref<any[]>([])
 const selectedSave = ref<any>(null)
 const newSaveName = ref('')
+const toast = reactive({ show: false, message: '', type: 'success' as 'success' | 'error' })
+
+const showToast = (message: string, type: 'success' | 'error' = 'success') => {
+  toast.show = true
+  toast.message = message
+  toast.type = type
+  setTimeout(() => { toast.show = false }, 2500)
+}
 
 const fetchSaves = async () => {
   try {
@@ -87,7 +103,7 @@ const fetchSaves = async () => {
     })
     saves.value = response.data
   } catch (error) {
-    console.error(parseApiError(error))
+    showToast(parseApiError(error), 'error')
   }
 }
 
@@ -106,9 +122,9 @@ const handleSave = async () => {
     })
     newSaveName.value = ''
     await fetchSaves()
-    alert('存档成功！')
+    showToast('存档成功')
   } catch (error) {
-    alert(parseApiError(error))
+    showToast(parseApiError(error), 'error')
   }
 }
 
@@ -118,9 +134,9 @@ const handleLoad = async () => {
   try {
     const response = await axios.get(`/api/save/${selectedSave.value.id}`)
     emit('load', response.data.data)
-    alert('读档成功！')
+    showToast('读档成功')
   } catch (error) {
-    alert(parseApiError(error))
+    showToast(parseApiError(error), 'error')
   }
 }
 
@@ -134,10 +150,7 @@ onMounted(fetchSaves)
 <style scoped>
 .save-load-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
   align-items: center;
@@ -146,11 +159,13 @@ onMounted(fetchSaves)
 }
 
 .save-load-panel {
-  background: rgba(0, 0, 0, 0.9);
-  border: 2px solid #4a4a8a;
+  position: relative;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
   border-radius: 12px;
   padding: 20px;
-  min-width: 400px;
+  width: 90%;
+  max-width: 460px;
 }
 
 .panel-header {
@@ -163,14 +178,15 @@ onMounted(fetchSaves)
 .close-btn {
   background: none;
   border: none;
-  color: #888;
+  color: var(--text-muted);
   font-size: 18px;
   cursor: pointer;
   padding: 4px 8px;
+  transition: color var(--transition-fast);
 }
 
 .close-btn:hover {
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .tabs {
@@ -182,17 +198,18 @@ onMounted(fetchSaves)
 .tabs button {
   flex: 1;
   padding: 10px;
-  background: #2a2a4a;
+  background: var(--bg-secondary);
   border: none;
-  color: #aaa;
+  color: var(--text-secondary);
   cursor: pointer;
   border-radius: 6px;
-  transition: all 0.3s;
+  transition: all var(--transition-normal);
+  font-family: var(--font-ui);
 }
 
 .tabs button.active {
-  background: #4a4a8a;
-  color: #ffd700;
+  background: var(--border-subtle);
+  color: var(--accent-gold);
 }
 
 .save-list {
@@ -204,20 +221,36 @@ onMounted(fetchSaves)
   display: flex;
   justify-content: space-between;
   padding: 12px;
-  background: #1a1a2e;
+  background: var(--bg-secondary);
   margin-bottom: 8px;
   border-radius: 6px;
   cursor: pointer;
-  transition: all 0.3s;
+  transition: all var(--transition-fast);
+  border: 1px solid transparent;
 }
 
 .save-item:hover {
-  background: #2a2a4a;
+  background: rgba(42, 42, 74, 0.8);
+}
+
+.save-item-selected {
+  border-color: var(--accent-gold);
+  background: rgba(42, 42, 74, 0.8);
+}
+
+.save-name {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.save-date {
+  color: var(--text-muted);
+  font-size: 12px;
 }
 
 .no-saves {
   text-align: center;
-  color: #666;
+  color: var(--text-muted);
   padding: 40px;
 }
 
@@ -230,10 +263,17 @@ onMounted(fetchSaves)
 
 .save-name-input {
   padding: 10px;
-  background: #1a1a2e;
-  border: 1px solid #4a4a8a;
-  color: #fff;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-primary);
   border-radius: 6px;
+  font-family: var(--font-ui);
+  transition: border-color var(--transition-fast);
+}
+
+.save-name-input:focus {
+  outline: none;
+  border-color: var(--accent-gold);
 }
 
 .action-button {
@@ -242,16 +282,55 @@ onMounted(fetchSaves)
   border-radius: 6px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s;
+  font-family: var(--font-ui);
+  transition: all var(--transition-normal);
 }
 
-.action-button.save {
+.action-save {
   background: linear-gradient(135deg, #4a8a4a, #3a7a3a);
   color: #fff;
 }
 
-.action-button.load {
-  background: linear-gradient(135deg, #4a4a8a, #3a3a7a);
+.action-save:hover {
+  box-shadow: 0 0 12px rgba(74, 138, 74, 0.4);
+}
+
+.action-load {
+  background: linear-gradient(135deg, var(--border-subtle), #3a3a7a);
   color: #fff;
+}
+
+.action-load:hover {
+  box-shadow: 0 0 12px rgba(74, 74, 138, 0.4);
+}
+
+/* Toast */
+.toast {
+  position: absolute;
+  bottom: -40px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 20px;
+  border-radius: 6px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.toast.success {
+  background: rgba(74, 138, 74, 0.9);
+  color: #fff;
+}
+
+.toast.error {
+  background: rgba(223, 74, 74, 0.9);
+  color: #fff;
+}
+
+.toast-enter-active, .toast-leave-active {
+  transition: all 0.3s ease;
+}
+.toast-enter-from, .toast-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(8px);
 }
 </style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,59 +1,98 @@
 <template>
-  <div class="home-page">
-    <header class="header">
-      <h1>学习主页</h1>
-      <div class="user-menu">
-        <span class="username">{{ authStore.user?.username }}</span>
-        <button @click="router.push('/settings')">设置</button>
-        <button @click="handleLogout">退出</button>
+  <div class="home-scene">
+    <!-- 背景星空粒子 -->
+    <div class="scene-particles">
+      <span v-for="i in 20" :key="i" class="particle" :style="particleStyle(i)" />
+    </div>
+
+    <!-- Phase 1: 主菜单 -->
+    <Transition name="fade">
+      <div v-if="phase === 'menu'" class="menu-phase">
+        <h1 class="game-title">苏 格 拉 底 学 习 系 统</h1>
+        <nav class="menu-list">
+          <a class="menu-item" @click="enterCharacterSelect">开 始 学 习</a>
+          <a class="menu-item" @click="router.push('/archive')">档 案 管 理</a>
+          <a class="menu-item" @click="router.push('/character')">角 色 设 定</a>
+          <a class="menu-item" @click="router.push('/settings')">系 统 设 置</a>
+          <a class="menu-item menu-item-muted" @click="handleLogout">退 出 登 录</a>
+        </nav>
       </div>
-    </header>
+    </Transition>
 
-    <nav class="nav">
-      <button @click="router.push('/character')">角色设定</button>
-      <button @click="router.push('/archive')">档案管理</button>
-    </nav>
-
-    <main class="main">
-      <section class="characters-section">
-        <h2>我的角色</h2>
-        <div class="characters-grid">
+    <!-- Phase 2: 角色选择 -->
+    <Transition name="fade">
+      <div v-if="phase === 'character'" class="character-phase">
+        <!-- 角色立绘区 -->
+        <div class="characters-stage">
           <div
             v-for="char in characters"
             :key="char.id"
-            class="character-card"
+            class="stage-character"
+            :class="{ selected: selectedCharacter?.id === char.id }"
             @click="selectCharacter(char)"
           >
-            <div class="char-avatar">
+            <div class="char-sprite">
               {{ char.name?.[0] || '?' }}
             </div>
-            <h3>{{ char.name }}</h3>
-            <p class="char-desc">{{ char.personality || '暂无描述' }}</p>
+            <span class="char-label">{{ char.name }}</span>
           </div>
-          <div class="character-card add-new" @click="router.push('/character')">
-            <span class="plus">+</span>
-            <p>创建新角色</p>
+          <div class="stage-character add-character" @click="router.push('/character')">
+            <div class="char-sprite char-sprite-add">＋</div>
+            <span class="char-label">新 建</span>
           </div>
         </div>
-      </section>
 
-      <section v-if="selectedCharacter" class="subjects-section">
-        <h2>选择学习科目 - {{ selectedCharacter.name }}</h2>
-        <div class="subjects-grid">
-          <div
-            v-for="subj in subjects"
-            :key="subj.id"
-            class="subject-card"
-            @click="startLearning(subj.id)"
-          >
-            <h3>{{ subj.name }}</h3>
-            <p>{{ subj.description || '暂无描述' }}</p>
-            <span class="target-level">{{ subj.target_level || '未设定目标' }}</span>
-          </div>
+        <!-- 对话框 -->
+        <div class="dialog-bar">
+          <template v-if="!selectedCharacter">
+            <span class="dialog-name">系统</span>
+            <p class="dialog-text">选择你今天的学习伙伴</p>
+          </template>
+          <template v-else>
+            <span class="dialog-name">{{ selectedCharacter.name }}</span>
+            <div v-if="subjects.length > 0" class="dialog-choices">
+              <p class="dialog-text">「今天想学什么呢？」</p>
+              <div
+                v-for="subj in subjects"
+                :key="subj.id"
+                class="choice-item"
+                @click="startLearning(subj.id)"
+              >
+                <span class="choice-arrow">▸</span>
+                {{ subj.name }}
+                <span v-if="subj.description" class="choice-desc">— {{ subj.description }}</span>
+              </div>
+              <div class="choice-item choice-new" @click="router.push('/character')">
+                <span class="choice-arrow">▸</span>
+                ＋ 新科目
+              </div>
+            </div>
+            <div v-else class="dialog-choices">
+              <p class="dialog-text">「还没有科目呢，去创建一个吧！」</p>
+              <div class="choice-item choice-new" @click="router.push('/character')">
+                <span class="choice-arrow">▸</span>
+                前往角色设定创建科目
+              </div>
+            </div>
+          </template>
         </div>
-      </section>
-    </main>
-    <div v-if="errorMessage" class="error-toast">{{ errorMessage }}</div>
+
+        <!-- 返回按钮 -->
+        <button class="back-btn" @click="phase = 'menu'">← 返回</button>
+      </div>
+    </Transition>
+
+    <!-- 空白时引导 -->
+    <Transition name="fade">
+      <div v-if="phase === 'character' && characters.length === 0 && !loadingCharacters" class="empty-guide">
+        <p>还没有角色，创建你的第一个 AI 教师吧！</p>
+      </div>
+    </Transition>
+
+    <!-- 错误提示 -->
+    <Transition name="fade">
+      <div v-if="errorMessage" class="toast-error">{{ errorMessage }}</div>
+    </Transition>
   </div>
 </template>
 
@@ -86,16 +125,21 @@ interface Subject {
   target_level?: string
 }
 
+const phase = ref<'menu' | 'character'>('menu')
 const characters = ref<Character[]>([])
 const subjects = ref<Subject[]>([])
 const selectedCharacter = ref<Character | null>(null)
+const loadingCharacters = ref(false)
 
 const fetchCharacters = async () => {
+  loadingCharacters.value = true
   try {
     const response = await axios.get('/api/character')
     characters.value = response.data
   } catch (error) {
     showError(error)
+  } finally {
+    loadingCharacters.value = false
   }
 }
 
@@ -108,6 +152,11 @@ const fetchSubjects = async (characterId: number) => {
   } catch (error) {
     showError(error)
   }
+}
+
+const enterCharacterSelect = () => {
+  phase.value = 'character'
+  fetchCharacters()
 }
 
 const selectCharacter = (char: Character) => {
@@ -124,151 +173,340 @@ const handleLogout = () => {
   router.push('/login')
 }
 
+const particleStyle = (i: number) => ({
+  left: `${(i * 37 + 13) % 100}%`,
+  top: `${(i * 53 + 7) % 100}%`,
+  animationDelay: `${(i * 0.7) % 5}s`,
+  animationDuration: `${3 + (i % 4)}s`,
+})
+
 onMounted(() => {
   fetchCharacters()
 })
 </script>
 
 <style scoped>
-.home-page {
+.home-scene {
   min-height: 100vh;
-  padding: 20px;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(ellipse at 50% 30%, #1a1a3e 0%, #0a0a1e 70%);
 }
 
-.header {
+/* === 星空粒子 === */
+.scene-particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.particle {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  background: rgba(255, 215, 0, 0.4);
+  border-radius: 50%;
+  animation: twinkle 4s ease-in-out infinite;
+}
+
+@keyframes twinkle {
+  0%, 100% { opacity: 0.2; transform: scale(1); }
+  50% { opacity: 0.8; transform: scale(1.5); }
+}
+
+/* === 页面过渡 === */
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.4s ease;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+
+/* === Phase 1: 主菜单 === */
+.menu-phase {
+  position: absolute;
+  inset: 0;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: center;
-  padding: 20px;
-  background: rgba(0, 0, 0, 0.5);
-  border-radius: 12px;
-  margin-bottom: 20px;
+  justify-content: center;
+  z-index: 1;
 }
 
-.header h1 {
+.game-title {
+  font-family: var(--font-dialogue);
+  font-size: 32px;
   color: #ffd700;
+  letter-spacing: 8px;
+  margin-bottom: 60px;
+  animation: titleGlow 3s ease-in-out infinite;
 }
 
-.user-menu {
+@keyframes titleGlow {
+  0%, 100% { text-shadow: 0 0 10px rgba(255, 215, 0, 0.3); }
+  50% { text-shadow: 0 0 30px rgba(255, 215, 0, 0.6), 0 0 60px rgba(255, 215, 0, 0.2); }
+}
+
+.menu-list {
   display: flex;
-  gap: 15px;
+  flex-direction: column;
   align-items: center;
-}
-
-.username {
-  color: #ffd700;
-}
-
-.user-menu button {
-  padding: 8px 16px;
-  background: #2a2a4a;
-  border: none;
-  color: #fff;
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.nav {
-  display: flex;
-  gap: 15px;
-  margin-bottom: 30px;
-}
-
-.nav button {
-  padding: 12px 24px;
-  background: #2a2a4a;
-  border: 1px solid #4a4a8a;
-  color: #fff;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.3s;
-}
-
-.nav button:hover {
-  background: #3a3a5a;
-  border-color: #ffd700;
-}
-
-h2 {
-  color: #ffd700;
-  margin-bottom: 20px;
-}
-
-.characters-grid, .subjects-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 20px;
 }
 
-.character-card {
-  background: rgba(0, 0, 0, 0.5);
-  border: 2px solid #4a4a8a;
-  border-radius: 12px;
-  padding: 20px;
-  text-align: center;
+.menu-item {
+  font-family: var(--font-dialogue);
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 6px;
   cursor: pointer;
-  transition: all 0.3s;
+  transition: all var(--transition-normal);
+  text-decoration: none;
+  position: relative;
+  padding: 4px 0;
 }
 
-.character-card:hover {
-  transform: translateY(-5px);
-  border-color: #ffd700;
+.menu-item:hover {
+  color: #ffd700;
+  text-shadow: 0 0 15px rgba(255, 215, 0, 0.5);
+  transform: scale(1.05);
 }
 
-.char-avatar {
-  width: 80px;
-  height: 80px;
-  background: linear-gradient(135deg, #4a4a8a, #2a2a4a);
-  border-radius: 50%;
+.menu-item-muted {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.35);
+  margin-top: 20px;
+}
+
+.menu-item-muted:hover {
+  color: rgba(255, 255, 255, 0.7);
+  text-shadow: none;
+}
+
+/* === Phase 2: 角色选择 === */
+.character-phase {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  z-index: 1;
+}
+
+.characters-stage {
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 48px;
+  padding-bottom: 40px;
+}
+
+.stage-character {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  transition: all var(--transition-normal);
+}
+
+.stage-character:hover {
+  transform: translateY(-8px);
+}
+
+.stage-character.selected {
+  transform: translateY(-12px) scale(1.05);
+}
+
+.char-sprite {
+  width: 100px;
+  height: 140px;
+  background: linear-gradient(180deg, rgba(74, 74, 138, 0.4) 0%, rgba(42, 42, 74, 0.6) 100%);
+  border: 2px solid rgba(74, 74, 138, 0.5);
+  border-radius: 12px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 32px;
+  font-size: 36px;
   color: #ffd700;
-  margin: 0 auto 15px;
+  font-family: var(--font-dialogue);
+  transition: all var(--transition-normal);
 }
 
-.add-new {
+.stage-character.selected .char-sprite {
+  border-color: #ffd700;
+  box-shadow: 0 0 20px rgba(255, 215, 0, 0.3);
+}
+
+.stage-character:hover .char-sprite {
+  border-color: rgba(255, 215, 0, 0.5);
+}
+
+.char-sprite-add {
   border-style: dashed;
+  color: rgba(74, 74, 138, 0.8);
+  font-size: 28px;
 }
 
-.plus {
-  font-size: 48px;
-  color: #4a4a8a;
+.char-sprite-add:hover {
+  color: #ffd700;
 }
 
-.subject-card {
-  background: rgba(0, 0, 0, 0.5);
-  border: 2px solid #4a4a8a;
-  border-radius: 12px;
-  padding: 20px;
-  cursor: pointer;
-  transition: all 0.3s;
-}
-
-.subject-card:hover {
-  border-color: #4a8a4a;
-}
-
-.target-level {
-  display: inline-block;
+.char-label {
   margin-top: 10px;
-  padding: 4px 12px;
-  background: #4a8a4a;
-  border-radius: 12px;
-  font-size: 12px;
+  font-family: var(--font-dialogue);
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 2px;
 }
 
-.error-toast {
-  position: fixed;
+.stage-character.selected .char-label {
+  color: #ffd700;
+}
+
+/* === 对话框 (底部横跨式) === */
+.dialog-bar {
+  position: relative;
+  min-height: 160px;
+  max-height: 280px;
+  background: rgba(0, 0, 0, 0.8);
+  border-top: 1px solid rgba(255, 215, 0, 0.2);
+  padding: 20px 40px;
+  animation: slideUp 0.3s ease-out;
+}
+
+.dialog-name {
+  display: inline-block;
+  font-family: var(--font-dialogue);
+  font-size: 15px;
+  color: #ffd700;
+  margin-bottom: 12px;
+  padding: 2px 12px;
+  background: linear-gradient(90deg, rgba(255, 215, 0, 0.15), transparent);
+  border-left: 2px solid #ffd700;
+}
+
+.dialog-text {
+  font-family: var(--font-dialogue);
+  font-size: 16px;
+  color: rgba(255, 255, 255, 0.9);
+  line-height: 1.8;
+  margin-bottom: 12px;
+}
+
+.dialog-choices {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.choice-item {
+  font-family: var(--font-dialogue);
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.75);
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  border-radius: 4px;
+}
+
+.choice-item:hover {
+  color: #ffd700;
+  background: rgba(255, 215, 0, 0.08);
+  padding-left: 24px;
+}
+
+.choice-arrow {
+  color: rgba(255, 215, 0, 0.6);
+  margin-right: 8px;
+}
+
+.choice-item:hover .choice-arrow {
+  color: #ffd700;
+}
+
+.choice-desc {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 13px;
+  margin-left: 4px;
+}
+
+.choice-new {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+/* === 返回按钮 === */
+.back-btn {
+  position: absolute;
   top: 20px;
+  left: 24px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  cursor: pointer;
+  z-index: 2;
+  transition: color var(--transition-fast);
+}
+
+.back-btn:hover {
+  color: #ffd700;
+}
+
+/* === 空白引导 === */
+.empty-guide {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  font-family: var(--font-dialogue);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 16px;
+  text-align: center;
+}
+
+/* === 错误 toast === */
+.toast-error {
+  position: fixed;
+  top: 24px;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(215, 58, 74, 0.9);
+  background: rgba(223, 74, 74, 0.9);
   color: #fff;
   padding: 10px 24px;
   border-radius: 8px;
   font-size: 14px;
   z-index: 100;
+}
+
+/* === 响应式 === */
+@media (max-width: 768px) {
+  .game-title {
+    font-size: 22px;
+    letter-spacing: 4px;
+    margin-bottom: 40px;
+  }
+
+  .menu-item {
+    font-size: 16px;
+    letter-spacing: 4px;
+  }
+
+  .characters-stage {
+    gap: 24px;
+  }
+
+  .char-sprite {
+    width: 72px;
+    height: 100px;
+    font-size: 28px;
+  }
+
+  .dialog-bar {
+    padding: 16px 20px;
+  }
 }
 </style>


### PR DESCRIPTION
## 关联 Issue
Part of #118 Phase C

## 变更概述
从 git dangling blobs 恢复丢失的 Galgame 风格 Home.vue 和主题化 SaveLoad.vue。

## Home.vue 功能
- 星空粒子背景 + 闪烁动画
- 竖排纯文字菜单（开始学习/档案管理/角色设定/系统设置/退出登录）
- 角色选择场景化：立绘占位符 + 底部对话框选择科目
- 新用户空白引导 + 错误 toast
- Fade 过渡动画 + 响应式

## SaveLoad.vue 改进
- CSS 变量主题化
- alert → toast 通知
- 选中存档金色高亮

## 自查
- [x] parseApiError + showError 已集成
- [x] auth token 通过 axios 全局默认 header 传递
- [x] 新用户空白引导文案
- [x] 退出登录调用 authStore.logout