### PR TITLE
fix: enforce world knowledge initialization invariant

### DIFF
--- a/backend/api/routes/archive.py
+++ b/backend/api/routes/archive.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from backend.api.routes.auth import get_current_user
@@ -253,13 +254,19 @@ def delete_character(
 def _ensure_world_knowledge(db: Session, world_id: int) -> None:
     knowledge = db.query(Knowledge).filter(Knowledge.world_id == world_id).first()
     if knowledge is None:
-        db.add(
-            Knowledge(
-                world_id=world_id,
-                graph={},
-            )
-        )
-        db.flush()
+        try:
+            with db.begin_nested():
+                db.add(
+                    Knowledge(
+                        world_id=world_id,
+                        graph={},
+                    )
+                )
+                db.flush()
+        except IntegrityError:
+            existing = db.query(Knowledge).filter(Knowledge.world_id == world_id).first()
+            if existing is None:
+                raise
 
 
 @router.post("/worlds", response_model=WorldResponse)

--- a/backend/tests/test_archive.py
+++ b/backend/tests/test_archive.py
@@ -1,5 +1,8 @@
 """Tests for archive CRUD endpoints (character, world, course)."""
 
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
 from backend.models.models import Knowledge
 
 
@@ -346,4 +349,78 @@ class TestWorldKnowledgeInitialization:
         assert second_subject.status_code == 200
         assert second_subject.json()["world_id"] == world_id
 
+        assert db_session.query(Knowledge).filter(Knowledge.world_id == world_id).count() == 1
+
+    def test_knowledge_unique_conflict_does_not_fail_subject_create(
+        self,
+        client,
+        auth_headers,
+        db_session,
+        monkeypatch,
+    ):
+        character = client.post(
+            "/api/character",
+            json={"name": "KnowledgeConcurrent", "type": "sage"},
+            headers=auth_headers,
+        )
+        assert character.status_code == 200
+        character_id = character.json()["id"]
+
+        world = client.post(
+            "/api/worlds",
+            json={"name": "Concurrent World", "description": "test"},
+            headers=auth_headers,
+        )
+        assert world.status_code == 200
+        world_id = world.json()["id"]
+
+        bind = client.post(
+            f"/api/worlds/{world_id}/characters",
+            json={"character_id": character_id, "role": "sage", "is_primary": True},
+            headers=auth_headers,
+        )
+        assert bind.status_code == 200
+
+        db_session.query(Knowledge).filter(Knowledge.world_id == world_id).delete()
+        db_session.commit()
+        assert db_session.query(Knowledge).filter(Knowledge.world_id == world_id).count() == 0
+
+        original_flush = db_session.flush
+        conflict_state = {"raised": False}
+
+        def flush_with_conflict(*args, **kwargs):
+            pending_knowledge = any(
+                isinstance(obj, Knowledge) and obj.world_id == world_id
+                for obj in db_session.new
+            )
+            if pending_knowledge and not conflict_state["raised"]:
+                other_session = sessionmaker(
+                    autocommit=False,
+                    autoflush=False,
+                    bind=db_session.bind,
+                )()
+                try:
+                    other_session.add(Knowledge(world_id=world_id, graph={}))
+                    other_session.commit()
+                finally:
+                    other_session.close()
+                conflict_state["raised"] = True
+                raise IntegrityError("INSERT INTO knowledge", {}, Exception("duplicate key"))
+            return original_flush(*args, **kwargs)
+
+        monkeypatch.setattr(db_session, "flush", flush_with_conflict)
+
+        create_subject = client.post(
+            "/api/subjects",
+            json={
+                "character_id": character_id,
+                "name": "Concurrent Safe Subject",
+                "description": "legacy resolver path",
+                "target_level": "beginner",
+            },
+            headers=auth_headers,
+        )
+        assert create_subject.status_code == 200
+        assert create_subject.json()["world_id"] == world_id
+        assert conflict_state["raised"] is True
         assert db_session.query(Knowledge).filter(Knowledge.world_id == world_id).count() == 1


### PR DESCRIPTION
## Summary
- enforce knowledge row creation whenever a world is created via /api/worlds
- enforce the same invariant in legacy /api/subjects auto-world path
- add regression tests to verify knowledge.graph initializes to {} in both flows

## Validation
- .venv/bin/ruff check --config backend/pyproject.toml backend/api/routes/archive.py backend/tests/test_archive.py
- cd backend && ../.venv/bin/pytest -q tests/test_archive.py
- cd backend && ../.venv/bin/pytest -q

Closes #129