### PR TITLE
feat: UI迁移 Phase 2 — 路由与导航语义对齐

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -44,13 +44,21 @@ const router = createRouter({
   routes
 })
 
-router.beforeEach((to, _from, next) => {
+let authInitialized = false
+
+router.beforeEach(async (to) => {
   const authStore = useAuthStore()
-  if (to.name !== 'Login' && !authStore.isAuthenticated) {
-    next({ name: 'Login' })
-  } else {
-    next()
+  if (!authInitialized) {
+    await authStore.initAuth()
+    authInitialized = true
   }
+
+  if (to.name === 'Login' && authStore.isAuthenticated) return { name: 'Home' }
+  if (to.name !== 'Login' && !authStore.isAuthenticated) {
+    return { name: 'Login', query: { redirect: to.fullPath } }
+  }
+
+  return true
 })
 
 export default router

--- a/frontend/src/utils/navigation.ts
+++ b/frontend/src/utils/navigation.ts
@@ -1,0 +1,27 @@
+import type { LocationQueryRaw } from 'vue-router'
+
+interface LearningQueryInput {
+  worldId?: number | null
+  sessionId?: number | null
+}
+
+const isPositiveInteger = (value: number | null | undefined): value is number =>
+  value != null && Number.isInteger(value) && value > 0
+
+export const parseQueryNumber = (value: unknown): number | undefined => {
+  const normalized = Array.isArray(value) ? value[0] : value
+  if (typeof normalized !== 'string' && typeof normalized !== 'number') return undefined
+  const parsed = Number(normalized)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
+export const buildLearningRoute = (courseId: number, queryInput: LearningQueryInput = {}) => {
+  const query: LocationQueryRaw = {}
+  if (isPositiveInteger(queryInput.worldId)) query.worldId = String(queryInput.worldId)
+  if (isPositiveInteger(queryInput.sessionId)) query.sessionId = String(queryInput.sessionId)
+
+  return {
+    path: `/learning/${courseId}`,
+    query,
+  }
+}

--- a/frontend/src/views/Archive.vue
+++ b/frontend/src/views/Archive.vue
@@ -116,6 +116,7 @@ import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
 import { parseApiError } from '@/utils/error'
+import { buildLearningRoute } from '@/utils/navigation'
 import EmotionTrajectory from '@/components/EmotionTrajectory.vue'
 
 const router = useRouter()
@@ -242,13 +243,10 @@ const loadSave = async (saveId: number) => {
       alert('分叉结果缺少课程信息')
       return
     }
-    router.push({
-      path: `/learning/${courseId}`,
-      query: {
-        worldId: String(data.world_id || ''),
-        sessionId: String(data.session_id || '')
-      }
-    })
+    router.push(buildLearningRoute(courseId, {
+      worldId: data.world_id,
+      sessionId: data.session_id,
+    }))
   } catch (error) {
     alert(parseApiError(error))
   }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -54,6 +54,7 @@ import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
 import { parseApiError } from '@/utils/error'
+import { buildLearningRoute } from '@/utils/navigation'
 import TimelineTree from '@/components/TimelineTree.vue'
 
 interface World {
@@ -127,14 +128,17 @@ const enterCourses = async () => {
 }
 
 const startLearning = (courseId: number) => {
-  router.push({ path: `/learning/${courseId}`, query: { worldId: String(selectedWorld.value?.id || '') } })
+  router.push(buildLearningRoute(courseId, { worldId: selectedWorld.value?.id }))
 }
 
 const branchFromCheckpoint = async (checkpoint: { id: number; save_name: string }) => {
   try {
     const branchName = prompt('请输入分叉名称（可选）') || undefined
     const res = await axios.post(`/api/checkpoints/${checkpoint.id}/branch`, { branch_name: branchName }, { headers: headers() })
-    router.push({ path: `/learning/${res.data.course_id}`, query: { worldId: String(res.data.world_id || selectedWorld.value?.id || '') } })
+    router.push(buildLearningRoute(res.data.course_id, {
+      worldId: res.data.world_id || selectedWorld.value?.id,
+      sessionId: res.data.session_id,
+    }))
   } catch (error) {
     showError(error)
   }

--- a/frontend/src/views/Learning.vue
+++ b/frontend/src/views/Learning.vue
@@ -72,6 +72,7 @@ import CheckpointPanel from '@/components/galgame/CheckpointPanel.vue'
 import KnowledgeGraph from '@/components/KnowledgeGraph.vue'
 import { parseApiError } from '@/utils/error'
 import { useAuthStore } from '@/stores/auth'
+import { buildLearningRoute, parseQueryNumber } from '@/utils/navigation'
 
 interface Message {
   id: number
@@ -86,8 +87,8 @@ const router = useRouter()
 const authStore = useAuthStore()
 
 const courseId = computed(() => Number(route.params.courseId))
-const worldId = ref(Number(route.query.worldId || 0))
-const sessionId = ref<number>()
+const worldId = ref(parseQueryNumber(route.query.worldId) ?? 0)
+const sessionId = ref<number | undefined>(parseQueryNumber(route.query.sessionId))
 const teacherName = ref('知者')
 const sageSprites = ref<Record<string, string>>({})
 const travelerSprites = ref<Record<string, string>>({})
@@ -215,9 +216,16 @@ const handleChoice = (choice: string) => sendMessage(choice)
 const handleBranched = (payload: { session_id: number; course_id: number }) => {
   sessionId.value = payload.session_id
   if (payload.course_id !== courseId.value) {
-    router.push(`/learning/${payload.course_id}`)
+    router.push(buildLearningRoute(payload.course_id, {
+      worldId: worldId.value,
+      sessionId: payload.session_id,
+    }))
     return
   }
+  void router.replace(buildLearningRoute(payload.course_id, {
+    worldId: worldId.value,
+    sessionId: payload.session_id,
+  }))
   void startLearning()
 }
 

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -74,10 +74,11 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { parseApiError } from '@/utils/error'
 
+const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
 
@@ -157,12 +158,20 @@ const showToast = (msg: string) => {
   setTimeout(() => { toast.value = '' }, 3000)
 }
 
+const getPostLoginRedirect = () => {
+  const redirect = route.query.redirect
+  if (typeof redirect === 'string' && redirect.startsWith('/') && !redirect.startsWith('//')) {
+    return redirect
+  }
+  return '/home'
+}
+
 const handleLogin = async () => {
   error.value = ''
   isLoading.value = true
   try {
     await authStore.login(username.value, password.value)
-    router.push('/home')
+    router.replace(getPostLoginRedirect())
   } catch (e: any) {
     error.value = parseApiError(e)
   } finally {


### PR DESCRIPTION
## 变更说明
- 路由守卫改为初始化鉴权后再判定，未登录访问受保护路由将跳转 `/login?redirect=...`
- 登录成功后按 redirect 回跳（无 redirect 时回 `/home`）
- 统一 Learning 导航参数构建：新增 `buildLearningRoute`，仅在需要时携带 `worldId/sessionId`
- 修正 Home / Archive / Learning 的跨页跳转参数一致性

## 范围边界
- 仅涉及路由、参数与鉴权语义
- 未改视觉、未改接口字段

## 验证
- frontend: `vue-tsc + vite build`

Closes #142