### PR TITLE
feat: UI迁移 Phase 4 - Home 世界主链迁移

### DIFF
--- a/frontend/src/components/TimelineTree.vue
+++ b/frontend/src/components/TimelineTree.vue
@@ -19,6 +19,10 @@
         <div class="session-meta">
           课程 {{ session.course_id }} · 阶段 {{ session.relationship_stage }}
         </div>
+        <div class="session-meta secondary">
+          开始于 {{ formatDate(session.started_at) }}
+          <span v-if="session.parent_checkpoint_id != null"> · 来源存档 #{{ session.parent_checkpoint_id }}</span>
+        </div>
       </div>
 
       <div v-if="checkpointsBySession.get(session.id)?.length" class="checkpoint-list">
@@ -28,7 +32,7 @@
           class="checkpoint-pill"
           @click="$emit('branch', { id: checkpoint.id, save_name: checkpoint.save_name })"
         >
-          {{ checkpoint.save_name }} · {{ formatDate(checkpoint.created_at) }}
+          {{ checkpoint.save_name }} · #{{ checkpoint.message_index }} · {{ formatDate(checkpoint.created_at) }}
         </button>
       </div>
     </div>
@@ -125,7 +129,7 @@ const orderedSessions = computed(() =>
   [...sessions.value].sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime()),
 )
 
-const sessionDepth = (sessionId: number): number => {
+const sessionDepthMap = computed(() => {
   const depthMemo = new Map<number, number>()
   const sessionById = new Map(sessions.value.map((session) => [session.id, session]))
 
@@ -151,8 +155,16 @@ const sessionDepth = (sessionId: number): number => {
     return depth
   }
 
-  return computeDepth(sessionId, new Set<number>())
-}
+  for (const session of sessions.value) {
+    if (!depthMemo.has(session.id)) {
+      computeDepth(session.id, new Set<number>())
+    }
+  }
+
+  return depthMemo
+})
+
+const sessionDepth = (sessionId: number): number => sessionDepthMap.value.get(sessionId) || 0
 
 const formatDate = (value: string): string => {
   const date = new Date(value)
@@ -188,7 +200,7 @@ onMounted(() => {
 .session-card {
   background: rgba(0, 0, 0, 0.45);
   border: 1px solid var(--border-subtle);
-  border-radius: 8px;
+  border-radius: var(--radius-world-card);
   padding: 10px 12px;
 }
 
@@ -205,6 +217,11 @@ onMounted(() => {
   font-size: 12px;
 }
 
+.session-meta.secondary {
+  margin-top: 2px;
+  color: rgba(170, 170, 170, 0.7);
+}
+
 .checkpoint-list {
   display: flex;
   flex-wrap: wrap;
@@ -216,7 +233,7 @@ onMounted(() => {
   background: rgba(42, 42, 74, 0.65);
   color: var(--text-secondary);
   border-radius: 999px;
-  padding: 4px 10px;
+  padding: 4px 12px;
   font-size: 12px;
   cursor: pointer;
 }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,50 +1,94 @@
 <template>
   <div class="home-page" :style="sceneStyle">
-    <div class="mask"></div>
-    <div class="content">
-      <Transition name="fade" mode="out-in">
-        <section v-if="phase === 'menu'" key="menu" class="panel galgame-panel">
-          <h1>苏格拉底学习系统</h1>
-          <button class="galgame-btn galgame-menu-item" @click="enterWorlds">开始学习</button>
-          <button class="galgame-btn galgame-menu-item" @click="router.push('/archive')">档案管理</button>
-          <button class="galgame-btn galgame-menu-item" @click="router.push('/character')">角色设定</button>
-          <button class="galgame-btn galgame-menu-item" @click="router.push('/settings')">系统设置</button>
-          <button class="galgame-btn galgame-menu-item muted" @click="logout">退出登录</button>
+    <div class="scene-overlay"></div>
+    <div class="scene-vignette"></div>
+
+    <div class="home-layout">
+      <Transition name="phase" mode="out-in">
+        <section v-if="phase === 'menu'" key="menu" class="phase-menu">
+          <div class="menu-brand">
+            <p class="menu-subtitle">Zhī Yù · Socratic Learning</p>
+            <h1>知 遇</h1>
+          </div>
+
+          <div class="menu-actions">
+            <button class="galgame-btn galgame-menu-item" :disabled="loadingWorlds" @click="enterWorlds">
+              {{ loadingWorlds ? '载入世界中…' : '开始学习' }}
+            </button>
+            <button class="galgame-btn galgame-menu-item" @click="router.push('/archive')">档案管理</button>
+            <button class="galgame-btn galgame-menu-item" @click="router.push('/character')">角色设定</button>
+            <button class="galgame-btn galgame-menu-item" @click="router.push('/settings')">系统设置</button>
+            <button class="galgame-btn galgame-menu-item muted" @click="logout">退出登录</button>
+          </div>
         </section>
 
-        <section v-else-if="phase === 'worlds'" key="worlds" class="panel galgame-panel">
-          <h2>选择世界</h2>
-          <div class="list">
-            <button v-for="world in worlds" :key="world.id" class="item galgame-world-card" @click="selectWorld(world)">
+        <section v-else-if="phase === 'worlds'" key="worlds" class="phase-panel galgame-panel">
+          <header class="phase-header">
+            <p>WORLD-FIRST FLOW</p>
+            <h2>选择世界</h2>
+          </header>
+
+          <div v-if="loadingWorlds" class="hint">世界加载中...</div>
+          <p v-else-if="worlds.length === 0" class="hint">暂无世界，请先在角色设定中创建。</p>
+
+          <div v-else class="world-grid">
+            <button
+              v-for="world in worlds"
+              :key="world.id"
+              class="galgame-world-card world-card"
+              @click="selectWorld(world)"
+            >
               <strong>{{ world.name }}</strong>
               <span>{{ world.description || '暂无描述' }}</span>
             </button>
           </div>
-          <button class="back galgame-btn galgame-menu-item" @click="phase = 'menu'">← 返回</button>
+
+          <button class="galgame-btn galgame-menu-item back-btn" @click="phase = 'menu'">← 返回主菜单</button>
         </section>
 
-        <section v-else-if="phase === 'memory'" key="memory" class="panel wide galgame-panel">
-          <h2>回忆库 · {{ selectedWorld?.name }}</h2>
+        <section v-else-if="phase === 'memory'" key="memory" class="phase-panel phase-memory galgame-panel">
+          <header class="phase-header">
+            <p>MEMORY VAULT</p>
+            <h2>回忆库 · {{ selectedWorld?.name }}</h2>
+          </header>
+
           <TimelineTree v-if="selectedWorld" :world-id="selectedWorld.id" @branch="branchFromCheckpoint" />
+
           <div class="actions">
-            <button class="galgame-btn galgame-menu-item" @click="enterCourses">进入课程选择</button>
-            <button class="back galgame-btn galgame-menu-item" @click="phase = 'worlds'">← 返回世界列表</button>
+            <button class="galgame-btn galgame-menu-item" :disabled="loadingCourses" @click="enterCourses">
+              {{ loadingCourses ? '载入课程中…' : '进入课程选择' }}
+            </button>
+            <button class="galgame-btn galgame-menu-item back-btn" @click="phase = 'worlds'">← 返回世界列表</button>
           </div>
         </section>
 
-        <section v-else key="courses" class="panel galgame-panel">
-          <h2>课程选择 · {{ selectedWorld?.name }}</h2>
-          <div class="list">
-            <button v-for="course in courses" :key="course.id" class="item galgame-world-card" @click="startLearning(course.id)">
+        <section v-else key="courses" class="phase-panel galgame-panel">
+          <header class="phase-header">
+            <p>COURSE SELECT</p>
+            <h2>课程选择 · {{ selectedWorld?.name }}</h2>
+          </header>
+
+          <div v-if="loadingCourses" class="hint">课程加载中...</div>
+          <p v-else-if="courses.length === 0" class="hint">该世界下暂无课程。</p>
+
+          <div v-else class="course-list">
+            <button
+              v-for="course in courses"
+              :key="course.id"
+              class="galgame-world-card world-card"
+              @click="startLearning(course.id)"
+            >
               <strong>{{ course.name }}</strong>
               <span>{{ course.description || '暂无描述' }}</span>
             </button>
           </div>
-          <button class="back galgame-btn galgame-menu-item" @click="phase = 'memory'">← 返回回忆库</button>
+
+          <button class="galgame-btn galgame-menu-item back-btn" @click="phase = 'memory'">← 返回回忆库</button>
         </section>
       </Transition>
-      <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
     </div>
+
+    <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
   </div>
 </template>
 
@@ -70,6 +114,12 @@ interface Course {
   description?: string
 }
 
+interface BranchResponse {
+  course_id?: number
+  world_id?: number
+  session_id?: number | null
+}
+
 const router = useRouter()
 const authStore = useAuthStore()
 const phase = ref<'menu' | 'worlds' | 'memory' | 'courses'>('menu')
@@ -77,6 +127,8 @@ const worlds = ref<World[]>([])
 const courses = ref<Course[]>([])
 const selectedWorld = ref<World | null>(null)
 const errorMessage = ref('')
+const loadingWorlds = ref(false)
+const loadingCourses = ref(false)
 
 const headers = () => ({ Authorization: `Bearer ${authStore.token}` })
 
@@ -88,56 +140,90 @@ const sceneStyle = computed(() => {
     : {}
 })
 
+const toPositiveInt = (value: unknown): number | undefined => {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
 const showError = (error: unknown) => {
   errorMessage.value = parseApiError(error)
   setTimeout(() => (errorMessage.value = ''), 4000)
 }
 
-const fetchWorlds = async () => {
+const fetchWorlds = async (): Promise<boolean> => {
+  loadingWorlds.value = true
   try {
     const res = await axios.get('/api/worlds', { headers: headers() })
-    worlds.value = res.data
+    worlds.value = Array.isArray(res.data) ? res.data : []
+    return true
   } catch (error) {
     showError(error)
+    return false
+  } finally {
+    loadingWorlds.value = false
   }
 }
 
-const fetchCourses = async () => {
-  if (!selectedWorld.value) return
+const fetchCourses = async (): Promise<boolean> => {
+  if (!selectedWorld.value) {
+    showError(new Error('请先选择世界'))
+    return false
+  }
+
+  loadingCourses.value = true
   try {
     const res = await axios.get(`/api/worlds/${selectedWorld.value.id}/courses`, { headers: headers() })
-    courses.value = res.data
+    courses.value = Array.isArray(res.data) ? res.data : []
+    return true
   } catch (error) {
     showError(error)
+    return false
+  } finally {
+    loadingCourses.value = false
   }
 }
 
 const enterWorlds = async () => {
-  await fetchWorlds()
-  phase.value = 'worlds'
+  const loaded = await fetchWorlds()
+  if (loaded) phase.value = 'worlds'
 }
 
-const selectWorld = async (world: World) => {
+const selectWorld = (world: World) => {
   selectedWorld.value = world
+  courses.value = []
   phase.value = 'memory'
 }
 
 const enterCourses = async () => {
-  await fetchCourses()
-  phase.value = 'courses'
+  const loaded = await fetchCourses()
+  if (loaded) phase.value = 'courses'
 }
 
 const startLearning = (courseId: number) => {
-  router.push(buildLearningRoute(courseId, { worldId: selectedWorld.value?.id }))
+  const worldId = selectedWorld.value?.id
+  if (!worldId) {
+    showError(new Error('请先选择世界'))
+    return
+  }
+  router.push(buildLearningRoute(courseId, { worldId }))
 }
 
 const branchFromCheckpoint = async (checkpoint: { id: number; save_name: string }) => {
   try {
-    const branchName = prompt('请输入分叉名称（可选）') || undefined
-    const res = await axios.post(`/api/checkpoints/${checkpoint.id}/branch`, { branch_name: branchName }, { headers: headers() })
-    router.push(buildLearningRoute(res.data.course_id, {
-      worldId: res.data.world_id || selectedWorld.value?.id,
-      sessionId: res.data.session_id,
+    const branchNameInput = window.prompt('请输入分叉名称（可选）')
+    if (branchNameInput === null) return
+
+    const trimmedBranchName = branchNameInput.trim()
+    const payload = trimmedBranchName ? { branch_name: trimmedBranchName } : {}
+    const res = await axios.post(`/api/checkpoints/${checkpoint.id}/branch`, payload, { headers: headers() })
+    const data = res.data as BranchResponse
+
+    const courseId = toPositiveInt(data.course_id)
+    if (!courseId) throw new Error('分叉失败：未返回有效课程')
+
+    router.push(buildLearningRoute(courseId, {
+      worldId: toPositiveInt(data.world_id) || selectedWorld.value?.id,
+      sessionId: toPositiveInt(data.session_id),
     }))
   } catch (error) {
     showError(error)
@@ -151,18 +237,168 @@ const logout = () => {
 </script>
 
 <style scoped>
-.home-page { min-height: 100vh; position: relative; background: radial-gradient(ellipse at 50% 30%, #1a1a3e 0%, #0a0a1e 70%); }
-.mask { position: absolute; inset: 0; background: rgba(8, 8, 20, 0.55); }
-.content { position: relative; z-index: 1; min-height: 100vh; display: flex; justify-content: center; align-items: center; padding: 24px; }
-.panel { width: 100%; max-width: 760px; padding: 24px; display: flex; flex-direction: column; gap: 12px; }
-.panel.wide { max-width: 980px; }
-h1,h2 { color: #ffd700; margin-bottom: 10px; }
-.muted { color: #aaa; }
-.list { display: flex; flex-direction: column; gap: 10px; max-height: 420px; overflow-y: auto; }
-.item span { color: #999; font-size: 12px; }
-.actions { display: flex; justify-content: space-between; gap: 10px; margin-top: 8px; }
-.back { text-align: center; }
-.error { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); background: rgba(223,74,74,.9); padding: 8px 14px; border-radius: 6px; }
-.fade-enter-active,.fade-leave-active { transition: transform .25s ease; }
-.fade-enter-from,.fade-leave-to { transform: translateY(8px); }
+.home-page {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background: radial-gradient(ellipse at 50% 30%, #1a1a3e 0%, #0a0a1e 70%);
+}
+
+.scene-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(10, 10, 30, 0.52), rgba(0, 0, 0, 0.72));
+}
+
+.scene-vignette {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 28%, rgba(0, 0, 0, 0.42) 100%);
+}
+
+.home-layout {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+}
+
+.phase-menu {
+  width: 100%;
+  max-width: 1080px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 32px;
+}
+
+.menu-brand h1 {
+  color: var(--accent-gold);
+  font-size: 52px;
+  letter-spacing: 14px;
+  text-shadow: 0 0 20px rgba(255, 215, 0, 0.28);
+}
+
+.menu-subtitle {
+  margin-bottom: 10px;
+  color: rgba(255, 255, 255, 0.45);
+  letter-spacing: 3px;
+}
+
+.menu-actions {
+  width: min(320px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.phase-panel {
+  width: 100%;
+  max-width: 1024px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.phase-memory {
+  max-width: 1120px;
+}
+
+.phase-header p {
+  color: rgba(255, 255, 255, 0.46);
+  letter-spacing: 3px;
+  font-size: 11px;
+  margin-bottom: 6px;
+}
+
+.phase-header h2 {
+  color: var(--accent-gold);
+  margin-bottom: 4px;
+}
+
+.world-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.course-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.world-card {
+  text-align: left;
+  width: 100%;
+}
+
+.world-card span {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.back-btn {
+  text-align: center;
+}
+
+.hint {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.muted {
+  color: #aaa;
+}
+
+.error {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3;
+  background: rgba(223, 74, 74, 0.92);
+  padding: 8px 14px;
+  border-radius: 6px;
+}
+
+.phase-enter-active,
+.phase-leave-active {
+  transition: transform 0.25s ease;
+}
+
+.phase-enter-from,
+.phase-leave-to {
+  transform: translateY(8px);
+}
+
+@media (max-width: 900px) {
+  .phase-menu {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .menu-brand h1 {
+    font-size: 40px;
+    letter-spacing: 10px;
+  }
+
+  .menu-actions {
+    width: 100%;
+    max-width: 420px;
+  }
+}
 </style>


### PR DESCRIPTION
## 变更说明
- Home 重构为四阶段流程：`menu -> worlds -> memory -> courses`，并保持 world-first 进入学习语义
- 串联真实接口：`/api/worlds`、`/api/worlds/{world_id}/courses`、`/api/worlds/{world_id}/timelines`、`/api/checkpoints/{checkpoint_id}/branch`
- 补齐阶段切换稳态：世界/课程加载态、空态、失败态，避免接口失败后仍推进阶段
- 分叉链路强化：对 branch 返回的 `course_id/world_id/session_id` 做有效性校验，再进入 Learning
- 时间线展示对齐接口字段：session 层级（parent checkpoint depth）、started_at、message_index、relationship_stage

## 验证
- `cd frontend && npm run build`

Closes #144