### PR TITLE
fix: add world relationship to MemoryFact model

### DIFF
--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -100,6 +100,7 @@ class MemoryFact(Base):
     expires_at = Column(DateTime, nullable=True)
 
     character = orm_relationship("Character", back_populates="memory_facts")
+    world = orm_relationship("World", back_populates="memory_facts")
 
 
 # =============================================================================


### PR DESCRIPTION
## PR 描述

修复 MemoryFact 模型缺少 world 关系的问题。

World.world 已定义 ，但 MemoryFact 缺少对应的  关系。

### 修改

:
- MemoryFact 添加 