### PR TITLE
feat(#204): 标记 Legacy /save/* 接口为废弃

### DIFF
--- a/backend/api/routes/save.py
+++ b/backend/api/routes/save.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -457,13 +458,19 @@ def _get_owned_course(
     return course
 
 
-# Legacy save endpoints for frontend compatibility.
+# Legacy save endpoints - DEPRECATED
+# Use /checkpoints/* endpoints instead. See Issue #204.
 @router.post("/save")
 async def create_save_legacy(
     payload: LegacySaveCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    warnings.warn(
+        "Legacy /save endpoints are deprecated. Use /checkpoints/* instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     course = _get_owned_course(db, current_user, payload.subject_id)
     checkpoint = await create_checkpoint(
         CheckpointCreate(
@@ -483,6 +490,11 @@ async def list_save_legacy(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    warnings.warn(
+        "Legacy /save endpoints are deprecated. Use /checkpoints/* instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     query = db.query(Checkpoint).filter(Checkpoint.user_id == current_user.id)
     session_course_cache: dict[int, int | None] = {}
     if subject_id is not None:
@@ -526,6 +538,11 @@ async def get_save_legacy(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    warnings.warn(
+        "Legacy /save endpoints are deprecated. Use /checkpoints/* instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     checkpoint = db.query(Checkpoint).filter(
         Checkpoint.id == save_id,
         Checkpoint.user_id == current_user.id,
@@ -580,6 +597,11 @@ async def delete_save_legacy(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    warnings.warn(
+        "Legacy /save endpoints are deprecated. Use /checkpoints/* instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return await delete_checkpoint(save_id, db, current_user)
 
 


### PR DESCRIPTION
## Issue
关联 Issue #204: P0: 清理 Legacy Save API 冗余接口

## 变更内容
Phase 1：为 4 个 Legacy 接口添加 DeprecationWarning

### 修改文件
- 

### 添加的警告
在以下函数中添加 :
-  (POST /save)
-  (GET /save)  
-  (GET /save/{save_id})
-  (DELETE /save/{save_id})

警告信息: 

## 后续步骤
- [x] Phase 0: 确认无前端 Legacy 调用（已由 Reviewer 完成）
- [x] Phase 1: 后端标记 Legacy 接口为废弃（本次 PR）
- [ ] Phase 2: 等待一个版本周期
- [ ] Phase 3: 移除 Legacy 接口代码