### PR TITLE
refactor(#211): P2 — 关系阶段常量统一

### DIFF
--- a/backend/api/routes/archive.py
+++ b/backend/api/routes/archive.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from backend.api.routes.auth import get_current_user
 from backend.db.database import get_db
+from backend.models import models as models_module
 from backend.models.models import (
     Character,
     ChatMessage,
@@ -586,14 +587,7 @@ def _build_world_response(world: World, db: Session, current_user_id: int = None
     relationship = None
     if latest_session and latest_session.relationship:
         stage = latest_session.relationship.get("stage", "stranger")
-        stage_map = {
-            "stranger": "初识",
-            "acquaintance": "相识",
-            "friend": "朋友",
-            "mentor": "导师",
-            "partner": "伙伴",
-        }
-        stage_label = stage_map.get(stage, stage)
+        stage_label = models_module.RELATIONSHIP_STAGE_LABELS.get(stage, stage)
         relationship = latest_session.relationship
 
     return WorldResponse(

--- a/backend/api/routes/save.py
+++ b/backend/api/routes/save.py
@@ -201,14 +201,9 @@ def _build_checkpoint_response(cp: Checkpoint, db: Session, user_id: int) -> Che
 
     stage = None
     if relationship:
-        stage_map = {
-            "stranger": "初识",
-            "acquaintance": "相识",
-            "friend": "朋友",
-            "mentor": "导师",
-            "partner": "伙伴",
-        }
-        stage = stage_map.get(relationship.get("stage", ""), relationship.get("stage"))
+        stage = models_module.RELATIONSHIP_STAGE_LABELS.get(
+            relationship.get("stage", ""), relationship.get("stage")
+        )
 
     date = cp.created_at.strftime("%Y-%m-%d %H:%M") if cp.created_at else None
 

--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -22,6 +22,16 @@ def _utcnow():
     return datetime.now(UTC)
 
 
+# Relationship stage labels (shared across routes)
+RELATIONSHIP_STAGE_LABELS = {
+    "stranger": "初识",
+    "acquaintance": "相识",
+    "friend": "朋友",
+    "mentor": "导师",
+    "partner": "伙伴",
+}
+
+
 def _default_relationship():
     return {
         "dimensions": {

--- a/frontend/src/components/galgame/HudBar.vue
+++ b/frontend/src/components/galgame/HudBar.vue
@@ -25,6 +25,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { RELATIONSHIP_STAGE_LABELS } from '@/constants/courseLevels'
 
 const props = defineProps<{
   emotion?: string
@@ -51,13 +52,8 @@ const EMOTION_LABELS: Record<string, string> = {
   anxiety: '焦虑', neutral: '平静',
 }
 
-const STAGE_LABELS: Record<string, string> = {
-  stranger: '陌生人', acquaintance: '熟人', friend: '朋友',
-  mentor: '导师', partner: '伙伴',
-}
-
 const emotionLabel = computed(() => EMOTION_LABELS[props.emotion || 'neutral'] || '平静')
-const stageLabel = computed(() => STAGE_LABELS[props.stage || 'stranger'] || '陌生人')
+const stageLabel = computed(() => RELATIONSHIP_STAGE_LABELS[props.stage || 'stranger'] || '初识')
 const mastery = computed(() => props.mastery ?? 0)
 </script>
 


### PR DESCRIPTION
## 集群B: #01+#03+#08

### 变更
- 提取 RELATIONSHIP_STAGE_LABELS 到 models.py（单一数据源）
- save.py + archive.py: 删除重复 stage_map，引用 models.py 常量
- galgame/HudBar.vue: 删除本地 STAGE_LABELS，改用 RELATIONSHIP_STAGE_LABELS

### 统计
- 删除 2 处重复 stage_map（后端）
- 删除 1 处重复 STAGE_LABELS（前端）
- 4 files changed, 18 insertions(+), 23 deletions(-)

Closes #211