### PR TITLE
refactor(#214): P5 — 版本号+SAVE_DIR 纳入 config 统一管理

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -39,8 +39,11 @@ class Settings(BaseSettings):
     # Features
     features_voice_enabled: bool = False
 
-    # Save directory
+    # Save directory (used by save_file_manager)
     save_directory: str = "./saves"
+
+    # Application version (single source of truth)
+    app_version: str = "1.0.0"
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Socratic Learning System",
     description="基于苏格拉底教学法的个性化学习系统",
-    version="1.0.0",
+    version=settings.app_version,
     lifespan=lifespan,
 )
 
@@ -50,7 +50,7 @@ app.add_middleware(
 
 @app.get("/")
 async def root():
-    return {"message": "Socratic Learning System API", "version": "1.0.0"}
+    return {"message": "Socratic Learning System API", "version": settings.app_version}
 
 
 @app.get("/health")

--- a/backend/services/save_file_manager.py
+++ b/backend/services/save_file_manager.py
@@ -14,8 +14,16 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# 默认存档根目录（相对于项目根目录）
-SAVE_DIR = Path("data/saves")
+# Issue #214: SAVE_DIR 从 config 获取，支持 .env 覆盖
+def _get_save_dir() -> Path:
+    try:
+        from backend.core.config import get_settings
+        return Path(get_settings().save_directory)
+    except Exception:
+        return Path("data/saves")
+
+
+SAVE_DIR = _get_save_dir()
 
 # 单文件大小上限 (10 MB)
 MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024


### PR DESCRIPTION
## 集群E: #03+#19

### 变更
- config.py 新增 app_version 字段（单一真实来源，可通过 .env 覆盖）
- main.py 消除两处硬编码 "1.0.0"，改用 settings.app_version
- save_file_manager.py SAVE_DIR 改从 config.save_directory 读取（支持 .env 覆盖）

Closes #214