### PR TITLE
refactor(Phase0): 删除 _ensure_world_knowledge 空操作函数

### DIFF
--- a/backend/api/routes/archive.py
+++ b/backend/api/routes/archive.py
@@ -512,11 +512,6 @@ def character_levelup(
 
 
 # World endpoints
-def _ensure_world_knowledge(db: Session, world_id: int) -> None:
-    """Knowledge graph is deprecated in P1 #183. This function is a no-op."""
-    pass
-
-
 def _get_world_characters_by_role(db: Session, world_id: int, role: str) -> list[SageInfo]:
     """Get all characters of a given role bound to a world. Primary first."""
     links = db.query(WorldCharacter).filter(
@@ -624,7 +619,6 @@ def create_world(
     )
     db.add(db_world)
     db.flush()
-    _ensure_world_knowledge(db, db_world.id)
     db.commit()
     db.refresh(db_world)
     return _build_world_response(db_world, db, current_user.id)
@@ -741,7 +735,6 @@ def create_world_character(
         is_primary=wc.is_primary,
     )
     db.add(db_wc)
-    _ensure_world_knowledge(db, world_id)
     db.commit()
     db.refresh(db_wc)
     return WorldCharacterResponse(
@@ -837,7 +830,6 @@ def set_world_character_primary(
             is_primary=True,
         )
         db.add(link)
-        _ensure_world_knowledge(db, world_id)
     else:
         link.is_primary = True
 


### PR DESCRIPTION
## Overview

Phase 0 死代码清理，删除废弃的 knowledge graph 相关空操作函数。

## Change List

- backend/api/routes/archive.py: 删除 _ensure_world_knowledge 函数及所有调用

## Self-Check

- [x]  通过
- [x]  零结果

## Linked Issues

Closes #222