### PR TITLE
refactor(frontend): Phase 4 前端架构统一 §4.1+§4.3

### DIFF
--- a/frontend/src/components/ErrorToast.vue
+++ b/frontend/src/components/ErrorToast.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+defineProps<{
+  message: string
+}>()
+</script>
+
+<template>
+  <p v-if="message" class="error-toast font-ui">{{ message }}</p>
+</template>
+
+<style scoped>
+.error-toast {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(223, 74, 74, 0.9);
+  padding: 8px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  z-index: 9999;
+  letter-spacing: 1px;
+  max-width: 80vw;
+  text-align: center;
+}
+</style>

--- a/frontend/src/composables/useAsync.ts
+++ b/frontend/src/composables/useAsync.ts
@@ -1,0 +1,24 @@
+import { ref } from 'vue'
+import { parseApiError } from '@/utils/error'
+
+export function useAsync<T>(fn: () => Promise<T>) {
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function execute() {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fn()
+      return result
+    } catch (err) {
+      error.value = parseApiError(err)
+      setTimeout(() => (error.value = null), 4000)
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { loading, error, execute }
+}


### PR DESCRIPTION
## Phase 4 第1批: §4.1 + §4.3

### §4.1 统一 error-toast 实现 (#33)
- 新增  组件
- 新增  composable

### §4.3 角色模板统一 (#15, #31)
- PERSONA_TEMPLATES 仅在 personaTemplates.ts 定义
- SAGE_TEMPLATES 仅在 characterPresets.ts 定义
- 验证：仅有9处引用，无重复定义

### 待后续批次
- §4.2: client.ts 使用统一
- §4.4: types/index.ts 分离