### PR TITLE
refactor(backend): Phase 5 后端清理 - 删除 tool_confirm 占位接口

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -68,11 +68,6 @@ def _get_greeting(stage: str, persona_name: str | None) -> str:
     return template.format(name=persona_name or "老师")
 
 
-class ToolConfirmRequest(BaseModel):
-    tool: str
-    query: str
-    reason: str
-
 
 # ---------------------------------------------------------------------------
 # Issue #212 helpers: extract duplicated patterns
@@ -315,21 +310,6 @@ async def send_message(
         memory_extracted_count=result.get("memory_extracted_count", 0),
     )
 
-
-# Confirm tool call
-@router.post("/chat/tool_confirm")
-async def confirm_tool(
-    tool_request: ToolConfirmRequest,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
-):
-    # Execute tool and return result
-    # This is a placeholder - will integrate actual tool execution
-    return {
-        "message": "Tool execution placeholder",
-        "tool": tool_request.tool,
-        "query": tool_request.query
-    }
 
 
 # End learning session


### PR DESCRIPTION
## Phase 5 后端清理

### #10 tool_confirm 占位接口
- 删除 learning.py 中的  占位接口（20行）
- 删除  Pydantic 模型

### 关联问题已通过之前 PR 修复
- #06 save.py 遗留接口：已删除（PR #235）
- #18 服务层数据库连接：已清理（PR #236）
- #20 ChatMessage 查询重复：已提取辅助函数（PR #236）