### PR TITLE
refactor(issue-242): 移除 learning_engine.py 中的 SessionLocal 自管连接

### DIFF
--- a/backend/services/learning_engine.py
+++ b/backend/services/learning_engine.py
@@ -29,13 +29,11 @@ from types import SimpleNamespace
 
 from sqlalchemy.orm import Session
 
-from backend.db.database import SessionLocal
 from backend.models.models import (
     Character,
     ChatMessage,
     LearnerProfile,
     RelationshipStageRecord,
-    TeacherPersona,
     _default_relationship,
 )
 from backend.models.models import (
@@ -83,15 +81,11 @@ class LearningEngine:
         self,
         session_id: int,
         user_message: str,
+        db: Session,
         user_api_key: str = None,
         provider: str = "claude",
-        db: Session | None = None,
     ) -> dict:
         """Process user message and generate teacher response"""
-        own_db = False
-        if db is None:
-            db = SessionLocal()
-            own_db = True
 
         try:
             # 1. Get session context
@@ -278,10 +272,7 @@ class LearningEngine:
             update_user_profile_after_chat(db, session.user_id, session.world_id)
 
             # 16. Persist DB changes
-            if own_db:
-                db.commit()
-            else:
-                db.flush()
+            db.flush()
 
             # 17. Return response (移除 <memory> 标签)
             clean_response = memory_extractor.strip_tags(llm_response)
@@ -307,9 +298,6 @@ class LearningEngine:
                 "type": "error",
                 "reply": "处理消息时出错，请重试"
             }
-        finally:
-            if own_db:
-                db.close()
 
     async def create_seed_memories(
         self,


### PR DESCRIPTION
## 修复 Issue #242

### 变更内容
1. **删除 SessionLocal 导入** - 不再自己创建数据库连接
2. **删除 TeacherPersona 导入** - Phase 1.5 DD1 已确认该模型已删除
3. **db 参数改为必填** - 从  改为 
4. **删除 own_db fallback 逻辑** - 不再有条件创建 SessionLocal
5. **统一使用 db.flush()** - 移除条件分支，直接使用 flush

### 验证
- 语法检查通过
- 模块导入成功
- 所有调用方（learning.py）都通过依赖注入传入 db 参数

### 影响范围
-  - 核心修改
- 无需修改调用方（learning.py 已正确传入 db）