### PR TITLE
refactor(issue-245): 统一 API 调用层 (#29 + #32)

### DIFF
--- a/frontend/src/api/archive.ts
+++ b/frontend/src/api/archive.ts
@@ -1,0 +1,55 @@
+/**
+ * Archive API Module
+ * Issue #29: 统一 API 调用层
+ */
+import client from './client'
+
+export const archiveApi = {
+  /**
+   * 获取学习日记列表
+   */
+  getDiaries: () =>
+    client.get('/learning_diary').then(res => res.data),
+
+  /**
+   * 创建学习日记
+   */
+  createDiary: (content: string) =>
+    client.post('/learning_diary', { content }).then(res => res.data),
+
+  /**
+   * 获取进度数据
+   */
+  getProgress: () =>
+    client.get('/progress').then(res => res.data),
+
+  /**
+   * 获取会话列表
+   */
+  getSessions: () =>
+    client.get('/sessions').then(res => res.data),
+
+  /**
+   * 获取情感轨迹
+   */
+  getEmotionTrajectory: (sessionId: number) =>
+    client.get(`/sessions/${sessionId}/emotion_trajectory`).then(res => res.data),
+
+  /**
+   * 获取课程列表
+   */
+  getCourses: () =>
+    client.get('/courses').then(res => res.data),
+
+  /**
+   * 获取世界列表（归档视图用）
+   */
+  getWorlds: () =>
+    client.get('/worlds').then(res => res.data),
+
+  /**
+   * 获取角色列表（归档视图用）
+   */
+  getCharacters: () =>
+    client.get('/characters').then(res => res.data),
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,26 @@
+/**
+ * Auth API Module
+ * Issue #29: 统一 API 调用层
+ */
+import client from './client'
+import type { LoginRequest, RegisterRequest } from '@/types'
+
+export const authApi = {
+  /**
+   * 用户登录
+   */
+  login: (data: LoginRequest) =>
+    client.post('/auth/login', data).then(res => res.data),
+
+  /**
+   * 用户注册
+   */
+  register: (data: RegisterRequest) =>
+    client.post('/auth/register', data).then(res => res.data),
+
+  /**
+   * 获取当前用户信息
+   */
+  me: () =>
+    client.get('/auth/me').then(res => res.data),
+}

--- a/frontend/src/api/course.ts
+++ b/frontend/src/api/course.ts
@@ -1,0 +1,37 @@
+/**
+ * Course API Module
+ * Issue #29: 统一 API 调用层
+ */
+import client from './client'
+
+export const courseApi = {
+  /**
+   * 获取课程详情
+   */
+  get: (courseId: number) =>
+    client.get(`/courses/${courseId}`).then(res => res.data),
+
+  /**
+   * 获取课程的导师列表
+   */
+  getSages: (courseId: number) =>
+    client.get(`/courses/${courseId}/sages`).then(res => res.data),
+
+  /**
+   * 获取课程的会话列表
+   */
+  getSessions: (courseId: number) =>
+    client.get(`/courses/${courseId}/sessions`).then(res => res.data),
+
+  /**
+   * 获取课程的记忆事实
+   */
+  getMemoryFacts: (courseId: number, statsOnly = true) =>
+    client.get(`/courses/${courseId}/memory-facts?stats_only=${statsOnly}`).then(res => res.data),
+
+  /**
+   * 开始学习会话
+   */
+  start: (courseId: number, sageId: number) =>
+    client.post(`/courses/${courseId}/start`, { sage_id: sageId }).then(res => res.data),
+}

--- a/frontend/src/api/world.ts
+++ b/frontend/src/api/world.ts
@@ -1,0 +1,74 @@
+/**
+ * World API Module
+ * Issue #29 + #32: 统一 API 调用层
+ */
+import client from './client'
+import type { World } from '@/types'
+
+export const worldApi = {
+  /**
+   * 获取世界列表
+   */
+  list: (): Promise<World[]> =>
+    client.get('/worlds').then(res => res.data),
+
+  /**
+   * 获取单个世界详情
+   */
+  get: (id: number): Promise<World> =>
+    client.get(`/worlds/${id}`).then(res => res.data),
+
+  /**
+   * 创建新世界
+   */
+  create: (data: { name: string; description?: string }): Promise<World> =>
+    client.post('/worlds', data).then(res => res.data),
+
+  /**
+   * 更新世界
+   */
+  update: (id: number, data: Partial<World>): Promise<World> =>
+    client.put(`/worlds/${id}`, data).then(res => res.data),
+
+  /**
+   * 删除世界
+   */
+  delete: (id: number): Promise<void> =>
+    client.delete(`/worlds/${id}`),
+
+  /**
+   * 获取世界的课程列表
+   */
+  getCourses: (id: number) =>
+    client.get(`/worlds/${id}/courses`).then(res => res.data),
+
+  /**
+   * 获取世界的角色列表
+   */
+  getCharacters: (id: number) =>
+    client.get(`/worlds/${id}/characters`).then(res => res.data),
+
+  /**
+   * 向世界添加角色
+   */
+  addCharacter: (worldId: number, characterId: number) =>
+    client.post(`/worlds/${worldId}/characters`, { character_id: characterId }),
+
+  /**
+   * 从世界移除角色
+   */
+  removeCharacter: (worldId: number, characterId: number) =>
+    client.delete(`/worlds/${worldId}/characters/${characterId}`),
+
+  /**
+   * 获取世界的存档列表
+   */
+  getCheckpoints: (id: number) =>
+    client.get(`/worlds/${id}/checkpoints`).then(res => res.data),
+
+  /**
+   * 获取世界时间线
+   */
+  getTimelines: (id: number) =>
+    client.get(`/worlds/${id}/timelines`).then(res => res.data),
+}

--- a/frontend/src/composables/useArchive.ts
+++ b/frontend/src/composables/useArchive.ts
@@ -1,0 +1,70 @@
+/**
+ * Archive Composable
+ * Issue #29: 统一 API 调用层
+ */
+import { ref } from 'vue'
+import { archiveApi } from '@/api/archive'
+
+export function useArchive() {
+  const diaries = ref<unknown[]>([])
+  const sessions = ref<unknown[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchDiaries() {
+    loading.value = true
+    error.value = null
+    try {
+      diaries.value = await archiveApi.getDiaries()
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '获取日记失败'
+      console.error('fetchDiaries error:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createDiary(content: string) {
+    try {
+      const newDiary = await archiveApi.createDiary(content)
+      diaries.value.unshift(newDiary)
+      return newDiary
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '创建日记失败'
+      throw e
+    }
+  }
+
+  async function fetchSessions() {
+    loading.value = true
+    error.value = null
+    try {
+      sessions.value = await archiveApi.getSessions()
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '获取会话列表失败'
+      console.error('fetchSessions error:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getEmotionTrajectory(sessionId: number) {
+    try {
+      return await archiveApi.getEmotionTrajectory(sessionId)
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '获取情感轨迹失败'
+      throw e
+    }
+  }
+
+  return {
+    diaries,
+    sessions,
+    loading,
+    error,
+    fetchDiaries,
+    createDiary,
+    fetchSessions,
+    getEmotionTrajectory,
+  }
+}

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -1,0 +1,71 @@
+/**
+ * Auth Composable
+ * Issue #29: 统一 API 调用层
+ */
+import { ref } from 'vue'
+import { authApi } from '@/api/auth'
+import type { LoginRequest, RegisterRequest } from '@/types'
+
+export function useAuth() {
+  const user = ref<unknown>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function login(data: LoginRequest) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await authApi.login(data)
+      // 假设登录成功后返回用户信息或 token
+      user.value = result
+      return result
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '登录失败'
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function register(data: RegisterRequest) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await authApi.register(data)
+      return result
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '注册失败'
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchCurrentUser() {
+    loading.value = true
+    error.value = null
+    try {
+      user.value = await authApi.me()
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '获取用户信息失败'
+      user.value = null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function logout() {
+    user.value = null
+    localStorage.removeItem('token')
+  }
+
+  return {
+    user,
+    loading,
+    error,
+    login,
+    register,
+    fetchCurrentUser,
+    logout,
+  }
+}

--- a/frontend/src/composables/useCourses.ts
+++ b/frontend/src/composables/useCourses.ts
@@ -1,0 +1,71 @@
+/**
+ * Courses Composable
+ * Issue #29: 统一 API 调用层
+ */
+import { ref } from 'vue'
+import { courseApi } from '@/api/course'
+
+export function useCourses() {
+  const course = ref<unknown>(null)
+  const courses = ref<unknown[]>([])
+  const sessions = ref<unknown[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchCourse(courseId: number) {
+    loading.value = true
+    error.value = null
+    try {
+      course.value = await courseApi.get(courseId)
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '获取课程失败'
+      console.error('fetchCourse error:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchCourses() {
+    loading.value = true
+    error.value = null
+    try {
+      courses.value = await courseApi.get(courseId)
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '获取课程列表失败'
+      console.error('fetchCourses error:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function startCourse(courseId: number, sageId: number) {
+    try {
+      const result = await courseApi.start(courseId, sageId)
+      return result
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '开始课程失败'
+      throw e
+    }
+  }
+
+  async function getMemoryFacts(courseId: number, statsOnly = true) {
+    try {
+      return await courseApi.getMemoryFacts(courseId, statsOnly)
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '获取记忆事实失败'
+      throw e
+    }
+  }
+
+  return {
+    course,
+    courses,
+    sessions,
+    loading,
+    error,
+    fetchCourse,
+    fetchCourses,
+    startCourse,
+    getMemoryFacts,
+  }
+}

--- a/frontend/src/composables/useWorlds.ts
+++ b/frontend/src/composables/useWorlds.ts
@@ -1,0 +1,71 @@
+/**
+ * Worlds Composable
+ * Issue #29 + #32: 统一 API 调用层
+ */
+import { ref } from 'vue'
+import { worldApi } from '@/api/world'
+import type { World } from '@/types'
+
+export function useWorlds() {
+  const worlds = ref<World[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchWorlds() {
+    loading.value = true
+    error.value = null
+    try {
+      worlds.value = await worldApi.list()
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '获取世界列表失败'
+      console.error('fetchWorlds error:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createWorld(data: { name: string; description?: string }) {
+    try {
+      const newWorld = await worldApi.create(data)
+      worlds.value.push(newWorld)
+      return newWorld
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '创建世界失败'
+      throw e
+    }
+  }
+
+  async function deleteWorld(id: number) {
+    try {
+      await worldApi.delete(id)
+      worlds.value = worlds.value.filter(w => w.id !== id)
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '删除世界失败'
+      throw e
+    }
+  }
+
+  async function updateWorld(id: number, data: Partial<World>) {
+    try {
+      const updated = await worldApi.update(id, data)
+      const index = worlds.value.findIndex(w => w.id === id)
+      if (index !== -1) {
+        worlds.value[index] = updated
+      }
+      return updated
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : '更新世界失败'
+      throw e
+    }
+  }
+
+  return {
+    worlds,
+    loading,
+    error,
+    fetchWorlds,
+    createWorld,
+    deleteWorld,
+    updateWorld,
+  }
+}


### PR DESCRIPTION
## 修复 Issue #245

Closes #245
关联: #29, #32

### Phase 1: 新建 API 模块
- api/world.ts - 世界相关 API
- api/archive.ts - 归档相关 API  
- api/course.ts - 课程相关 API
- api/auth.ts - 认证相关 API

### Phase 2: 新建 Composables
- composables/useWorlds.ts
- composables/useArchive.ts
- composables/useCourses.ts
- composables/useAuth.ts

### 后续步骤
- [ ] 迁移 Login.vue 使用 useAuth
- [ ] 迁移 Archive.vue 使用 useArchive
- [ ] 迁移 Worlds.vue 使用 useWorlds
- [ ] 迁移 WorldDetail.vue 使用 useWorldDetail
- [ ] 迁移 Character.vue 使用 characterApi
- [ ] 迁移 CoursePage.vue 使用 useCourses
- [ ] 删除 stores/world.ts（死代码）