### PR TITLE
refactor(issue-244): 统一 Toast 通知系统 (#27 + #33)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="app">
+    <ToastContainer />
     <router-view v-slot="{ Component }">
       <Transition name="page-fade">
         <component :is="Component" />
@@ -9,7 +10,11 @@
 </template>
 
 <script setup lang="ts">
-// Root component — just provides page-level fade transition
+/**
+ * Root component
+ * Issue #27 + #33: 统一 Toast 通知系统
+ */
+import ToastContainer from '@/components/ToastContainer.vue'
 </script>
 
 <style>

--- a/frontend/src/components/ErrorToast.vue
+++ b/frontend/src/components/ErrorToast.vue
@@ -1,26 +1,78 @@
 <script setup lang="ts">
-defineProps<{
+/**
+ * ErrorToast Component
+ * Issue #27 + #33: 统一 Toast 通知系统
+ */
+import { ref, watch } from 'vue'
+
+const props = defineProps<{
   message: string
+  type?: 'error' | 'success' | 'warning'
+  duration?: number
 }>()
+
+const visible = ref(true)
+
+watch(() => props.message, (newMsg) => {
+  if (newMsg) {
+    visible.value = true
+    // 自动消失
+    if (props.duration && props.duration > 0) {
+      setTimeout(() => {
+        visible.value = false
+      }, props.duration)
+    }
+  }
+}, { immediate: true })
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const typeColors = {
+  error: 'rgba(223, 74, 74, 0.9)',
+  success: 'rgba(34, 197, 94, 0.9)',
+  warning: 'rgba(251, 191, 36, 0.9)'
+}
 </script>
 
 <template>
-  <p v-if="message" class="error-toast font-ui">{{ message }}</p>
+  <Transition name="toast">
+    <p 
+      v-if="visible" 
+      class="error-toast font-ui"
+      :style="{ background: type ? typeColors[type] : typeColors.error }"
+      @click="emit('close')"
+    >
+      {{ message }}
+    </p>
+  </Transition>
 </template>
 
 <style scoped>
 .error-toast {
-  position: fixed;
-  top: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(223, 74, 74, 0.9);
   padding: 8px 14px;
   border-radius: 6px;
   font-size: 13px;
-  z-index: 9999;
   letter-spacing: 1px;
   max-width: 80vw;
   text-align: center;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.3s ease;
+}
+
+.toast-enter-from {
+  opacity: 0;
+  transform: translateY(-20px);
+}
+
+.toast-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
 }
 </style>

--- a/frontend/src/components/ToastContainer.vue
+++ b/frontend/src/components/ToastContainer.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+/**
+ * ToastContainer Component
+ * Issue #27 + #33: 统一 Toast 通知系统
+ */
+import { useToast } from '@/composables/useToast'
+import ErrorToast from './ErrorToast.vue'
+
+const { toasts, remove } = useToast()
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="toast-container">
+      <TransitionGroup name="toast">
+        <ErrorToast
+          v-for="toast in toasts"
+          :key="toast.id"
+          :message="toast.message"
+          :type="toast.type"
+          :duration="toast.duration"
+          @close="remove(toast.id)"
+        />
+      </TransitionGroup>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  top: 20px;
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  pointer-events: none;
+  z-index: 9999;
+  gap: 8px;
+}
+
+.toast-container > * {
+  pointer-events: auto;
+}
+
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.3s ease;
+}
+
+.toast-enter-from {
+  opacity: 0;
+  transform: translateY(-20px);
+}
+
+.toast-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+</style>

--- a/frontend/src/composables/useToast.ts
+++ b/frontend/src/composables/useToast.ts
@@ -1,0 +1,64 @@
+/**
+ * Toast Composable
+ * Issue #27 + #33: 统一 Toast 通知系统
+ */
+import { ref } from 'vue'
+
+export interface Toast {
+  id: number
+  message: string
+  type: 'error' | 'success' | 'warning'
+  duration: number
+}
+
+// 全局 toast 状态
+const toasts = ref<Toast[]>([])
+
+export function useToast() {
+  function show(
+    message: string,
+    type: Toast['type'] = 'error',
+    duration: number = 4000
+  ): number {
+    const id = Date.now() + Math.random()
+    toasts.value.push({ id, message, type, duration })
+    
+    // 自动移除
+    if (duration > 0) {
+      setTimeout(() => {
+        remove(id)
+      }, duration)
+    }
+    
+    return id
+  }
+
+  function remove(id: number) {
+    const index = toasts.value.findIndex(t => t.id === id)
+    if (index > -1) {
+      toasts.value.splice(index, 1)
+    }
+  }
+
+  // 便捷方法
+  function error(message: string, duration = 4000) {
+    return show(message, 'error', duration)
+  }
+
+  function success(message: string, duration = 4000) {
+    return show(message, 'success', duration)
+  }
+
+  function warning(message: string, duration = 4000) {
+    return show(message, 'warning', duration)
+  }
+
+  return {
+    toasts,
+    show,
+    remove,
+    error,
+    success,
+    warning
+  }
+}

--- a/frontend/src/views/CoursePage.vue
+++ b/frontend/src/views/CoursePage.vue
@@ -261,7 +261,7 @@ const goBack = () => {
 
 const handleStartLearning = () => {
   if (sages.value.length === 0) {
-    alert('请先添加知者')
+    toast.warning('请先添加知者')
     return
   }
   if (sages.value.length === 1) {
@@ -293,7 +293,7 @@ const startLearningWithSage = async (sageId: number) => {
     })
   } catch (error) {
     console.error('Failed to start session:', error)
-    alert('启动学习会话失败')
+    toast.error('启动学习会话失败')
   }
 }
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -259,7 +259,7 @@ const saveSettings = async () => {
 }
 
 const handleExport = () => {
-  alert('数据导出功能开发中')
+  toast.info('数据导出功能开发中')
 }
 
 const handleLogout = () => {


### PR DESCRIPTION
## 修复 Issue #244

Closes #244
关联: #27, #33

### 新建文件
- composables/useToast.ts - 全局 Toast 状态管理
- components/ToastContainer.vue - 全局 Toast 展示层

### 修改文件
- ErrorToast.vue - 扩展支持 error/success/warning 类型
- App.vue - 集成 ToastContainer
- CoursePage.vue - alert() → toast.warning()/toast.error()
- Settings.vue - alert() → toast.info()

### 后续步骤
- [ ] 简化 WorldDetail.vue（移除本地 showError）
- [ ] 简化 Worlds.vue（移除本地 showError）
- [ ] 简化 Home.vue
- [ ] 简化其他组件中的重复 error-toast