### PR TITLE
feat: ProgressFacade — unify progress reads, stop PT dual-write

### DIFF
--- a/backend/api/routes/archive.py
+++ b/backend/api/routes/archive.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
@@ -15,7 +15,6 @@ from backend.models.models import (
     Character,
     ChatMessage,
     Course,
-    FSRSState,
     LearnerProfile,
     LearningDiary,
     MemoryFact,
@@ -33,7 +32,6 @@ from backend.services.user_llm_settings import (
     update_generation_params,
     update_provider_settings,
 )
-from backend.services import spaced_repetition
 
 router = APIRouter()
 
@@ -1788,9 +1786,12 @@ def get_learning_diaries(
 @router.post("/progress", response_model=ProgressTrackingResponse)
 def create_progress(
     progress: ProgressTrackingCreate,
+    response: Response,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
+    from backend.services.progress_facade import progress_facade
+
     course = db.query(Course).join(World, Course.world_id == World.id).filter(
         Course.id == progress.course_id,
         World.user_id == current_user.id,
@@ -1798,52 +1799,72 @@ def create_progress(
     if not course:
         raise HTTPException(status_code=404, detail="Course not found")
 
-    db_progress = ProgressTracking(
-        **progress.model_dump(),
-        user_id=current_user.id
+    for key, value in progress_facade.progress_compat_headers(progress.course_id).items():
+        response.headers[key] = value
+
+    db_progress = progress_facade.create_progress_compat(
+        db,
+        user_id=current_user.id,
+        course_id=progress.course_id,
+        topic=progress.topic,
+        mastery_level=progress.mastery_level,
+        next_review=progress.next_review,
     )
-    db.add(db_progress)
     db.commit()
-    db.refresh(db_progress)
+    if hasattr(db_progress, "__mapper__"):
+        db.refresh(db_progress)
     return db_progress
 
 
 @router.get("/progress", response_model=list[ProgressTrackingResponse])
 def get_progress(
+    response: Response,
     course_id: int | None = None,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
 ):
-    query = db.query(ProgressTracking).join(Course, ProgressTracking.course_id == Course.id).join(
-        World, Course.world_id == World.id
-    ).filter(
-        ProgressTracking.user_id == current_user.id,
-        World.user_id == current_user.id,
-    )
-    if course_id:
-        query = query.filter(ProgressTracking.course_id == course_id)
-    return query.all()
+    from backend.services.progress_facade import progress_facade
+
+    for key, value in progress_facade.progress_compat_headers(course_id).items():
+        response.headers[key] = value
+    if course_id is not None:
+        canonical_index = progress_facade.get_canonical_lesson_index(
+            db, course_id, current_user.id,
+        )
+        response.headers["X-Canonical-Current-Lesson-Index"] = str(canonical_index)
+
+    return progress_facade.list_compat_progress_rows(db, current_user.id, course_id)
 
 
 @router.put("/progress/{progress_id}", response_model=ProgressTrackingResponse)
 def update_progress(
     progress_id: int,
     progress: ProgressTrackingCreate,
+    response: Response,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    db_progress = db.query(ProgressTracking).filter(
-        ProgressTracking.id == progress_id,
-        ProgressTracking.user_id == current_user.id
-    ).first()
-    if not db_progress:
+    from backend.services.progress_facade import progress_facade
+
+    for key, value in progress_facade.progress_compat_headers(progress.course_id).items():
+        response.headers[key] = value
+
+    try:
+        db_progress = progress_facade.update_progress_compat(
+            db,
+            progress_id=progress_id,
+            user_id=current_user.id,
+            course_id=progress.course_id,
+            topic=progress.topic,
+            mastery_level=progress.mastery_level,
+            next_review=progress.next_review,
+        )
+    except LookupError:
         raise HTTPException(status_code=404, detail="Progress not found")
 
-    for key, value in progress.model_dump(exclude_unset=True).items():
-        setattr(db_progress, key, value)
-
     db.commit()
-    db.refresh(db_progress)
+    if hasattr(db_progress, "__mapper__"):
+        db.refresh(db_progress)
     return db_progress
 
 
@@ -1865,88 +1886,52 @@ class ReviewResponse(BaseModel):
 def review_progress(
     progress_id: int,
     req: ReviewRequest,
+    response: Response,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """Record a review for a topic and compute next review date via FSRS."""
-    db_progress = db.query(ProgressTracking).join(Course, ProgressTracking.course_id == Course.id).join(
-        World, Course.world_id == World.id
-    ).filter(
-        ProgressTracking.id == progress_id,
-        ProgressTracking.user_id == current_user.id,
-        World.user_id == current_user.id,
-    ).first()
-    if not db_progress:
-        raise HTTPException(status_code=404, detail="Progress not found")
+    from backend.services.progress_facade import progress_facade
 
-    course = db.query(Course).filter(Course.id == db_progress.course_id).first()
-    if not course:
-        raise HTTPException(status_code=404, detail="Course not found")
+    response.headers["Deprecation"] = "true"
 
-    # [TR-B4] FSRSState is per-(user, concept) cross-world; world_id is no
-    # longer in the unique key.
-    fsrs_state_row = db.query(FSRSState).filter(
-        FSRSState.user_id == current_user.id,
-        FSRSState.concept_id == db_progress.topic,
-    ).first()
-
-    # [TODO-T7] Use card_data as authoritative state — cherry-picking columns
-    # loses card_id/state/step which py-fsrs Card.from_dict requires.
-    existing_fsrs_state = fsrs_state_row.card_data if fsrs_state_row else None
-
-    result = spaced_repetition.review(existing_fsrs_state, req.rating)
-
-    db_progress.last_review = result["last_review"]
-    db_progress.next_review = result["due"]
-    db_progress.mastery_level = result["mastery_level"]
-
-    fsrs_payload = result["fsrs_state"]
-    if fsrs_state_row is None:
-        fsrs_state_row = FSRSState(
+    try:
+        result = progress_facade.record_review_compat(
+            db,
+            progress_id=progress_id,
             user_id=current_user.id,
-            world_id=course.world_id,  # diagnostic only
-            concept_id=db_progress.topic,
+            rating=req.rating,
         )
-        db.add(fsrs_state_row)
-
-    fsrs_state_row.card_data = fsrs_payload
-    fsrs_state_row.difficulty = fsrs_payload.get("difficulty")
-    fsrs_state_row.stability = fsrs_payload.get("stability")
-    fsrs_state_row.reps = (fsrs_state_row.reps or 0) + 1
-    fsrs_state_row.last_review = result["last_review"]
-    fsrs_state_row.next_review = result["due"]
+    except LookupError as exc:
+        detail = str(exc) or "Progress not found"
+        raise HTTPException(status_code=404, detail=detail)
 
     db.commit()
-    db.refresh(db_progress)
 
     return ReviewResponse(
-        id=db_progress.id,
-        topic=db_progress.topic,
-        mastery_level=db_progress.mastery_level,
+        id=result["id"],
+        topic=result["topic"],
+        mastery_level=result["mastery_level"],
         retrievability=result["retrievability"],
-        next_review=db_progress.next_review,
-        last_review=db_progress.last_review,
+        next_review=result["next_review"],
+        last_review=result["last_review"],
     )
 
 
 @router.get("/progress/due", response_model=list[ProgressTrackingResponse])
 def get_due_reviews(
+    response: Response,
     course_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """Get topics that are due for review (next_review <= now)."""
-    now = datetime.now(UTC)
-    query = db.query(ProgressTracking).join(Course, ProgressTracking.course_id == Course.id).join(
-        World, Course.world_id == World.id
-    ).filter(
-        ProgressTracking.user_id == current_user.id,
-        ProgressTracking.next_review <= now,
-        World.user_id == current_user.id,
-    )
-    if course_id:
-        query = query.filter(ProgressTracking.course_id == course_id)
-    return query.order_by(ProgressTracking.next_review).all()
+    from backend.services.progress_facade import progress_facade
+
+    for key, value in progress_facade.progress_compat_headers(course_id).items():
+        response.headers[key] = value
+
+    return progress_facade.list_due_reviews_compat(db, current_user.id, course_id)
 
 
 # Settings endpoints

--- a/backend/api/routes/textbook.py
+++ b/backend/api/routes/textbook.py
@@ -856,9 +856,8 @@ def get_course_progress(
     """获取课程教学进度"""
     course = _get_course_with_auth(course_id, db, current_user)
 
-    from backend.services.teaching_planner import teaching_planner
-    progress = teaching_planner.get_progress(db, course)
-    return progress
+    from backend.services.progress_facade import progress_facade
+    return progress_facade.get_lesson_progress(db, course, current_user.id)
 
 
 @router.post("/courses/{course_id}/advance", response_model=LessonProgressResponse)
@@ -897,8 +896,8 @@ def get_course_mastery(
     """获取课程概念掌握度概览"""
     _get_course_with_auth(course_id, db, current_user)
 
-    from backend.services.mastery_tracker import mastery_tracker
-    return mastery_tracker.get_course_mastery(db, course_id, current_user.id)
+    from backend.services.progress_facade import progress_facade
+    return progress_facade.get_course_mastery(db, course_id, current_user.id)
 
 
 class GenerateDescriptionRequest(BaseModel):

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -49,6 +49,8 @@ class Settings(BaseSettings):
 
     # Features
     features_voice_enabled: bool = False
+    # ProgressFacade — set false to restore archive direct ProgressTracking writes
+    use_progress_facade: bool = True
 
     # Save directory (used by save_file_manager)
     save_directory: str = ""

--- a/backend/services/progress_facade.py
+++ b/backend/services/progress_facade.py
@@ -1,0 +1,438 @@
+"""Progress facade — unified lesson progress read + compat write surface.
+
+Canonical sources:
+- Lesson pointer: CourseProgress via teaching_planner
+- Concept mastery: ConceptMastery via mastery_tracker
+
+ProgressTracking is compat-read only when ``use_progress_facade`` is enabled;
+new rows must not be inserted through this facade.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from backend.core.config import get_settings
+from backend.models.models import (
+    ConceptMastery,
+    Course,
+    FSRSState,
+    ProgressTracking,
+    World,
+)
+from backend.services import spaced_repetition
+from backend.services.mastery_tracker import mastery_tracker
+from backend.services.teaching_planner import teaching_planner
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CompatProgressView:
+    """Synthetic ProgressTracking-shaped row for compat responses without INSERT."""
+
+    id: int
+    user_id: int
+    course_id: int
+    topic: str
+    mastery_level: int
+    next_review: datetime | None
+    last_review: datetime | None
+    topic_type: str = "concept"
+
+
+def use_progress_facade() -> bool:
+    """Feature flag — set USE_PROGRESS_FACADE=false to restore archive direct writes."""
+    return get_settings().use_progress_facade
+
+
+def skip_progress_tracking_writes() -> bool:
+    return use_progress_facade()
+
+
+def progress_compat_headers(course_id: int | None = None) -> dict[str, str]:
+    headers = {"Deprecation": "true"}
+    if course_id is not None:
+        headers["Link"] = f'</api/courses/{course_id}/progress>; rel="successor-version"'
+    return headers
+
+
+def get_lesson_progress(db: Session, course: Course, user_id: int) -> dict[str, Any]:
+    """Canonical lesson progress (CourseProgress / LessonPlan)."""
+    _ = user_id  # caller supplies for auth symmetry; planner reads course.world
+    return teaching_planner.get_progress(db, course)
+
+
+def get_canonical_lesson_index(db: Session, course_id: int, user_id: int) -> int:
+    course = (
+        db.query(Course)
+        .join(World, Course.world_id == World.id)
+        .filter(Course.id == course_id, World.user_id == user_id)
+        .first()
+    )
+    if not course:
+        return 0
+    return get_lesson_progress(db, course, user_id).get("current_index", 0)
+
+
+def get_course_mastery(db: Session, course_id: int, user_id: int) -> dict[str, Any]:
+    return mastery_tracker.get_course_mastery(db, course_id, user_id)
+
+
+def list_compat_progress_rows(
+    db: Session,
+    user_id: int,
+    course_id: int | None = None,
+) -> list[ProgressTracking | CompatProgressView]:
+    """Read legacy ProgressTracking rows for archive GET /progress."""
+    query = (
+        db.query(ProgressTracking)
+        .join(Course, ProgressTracking.course_id == Course.id)
+        .join(World, Course.world_id == World.id)
+        .filter(
+            ProgressTracking.user_id == user_id,
+            World.user_id == user_id,
+        )
+    )
+    if course_id is not None:
+        query = query.filter(ProgressTracking.course_id == course_id)
+    return list(query.all())
+
+
+def _upsert_concept_mastery(
+    db: Session,
+    *,
+    user_id: int,
+    topic: str,
+    mastery_level: int,
+    last_review: datetime | None = None,
+) -> ConceptMastery:
+    now = last_review or datetime.now(UTC)
+    row = (
+        db.query(ConceptMastery)
+        .filter(
+            ConceptMastery.user_id == user_id,
+            ConceptMastery.concept_id == topic,
+        )
+        .first()
+    )
+    if row:
+        row.mastery_level = mastery_level
+        row.last_review = now
+    else:
+        row = ConceptMastery(
+            user_id=user_id,
+            concept_id=topic,
+            mastery_level=mastery_level,
+            last_review=now,
+        )
+        db.add(row)
+    db.flush()
+    return row
+
+
+def _find_existing_progress_tracking(
+    db: Session,
+    *,
+    user_id: int,
+    course_id: int,
+    topic: str,
+) -> ProgressTracking | None:
+    return (
+        db.query(ProgressTracking)
+        .filter(
+            ProgressTracking.course_id == course_id,
+            ProgressTracking.user_id == user_id,
+            ProgressTracking.topic == topic,
+        )
+        .first()
+    )
+
+
+def _synthetic_compat_row(
+    *,
+    user_id: int,
+    course_id: int,
+    topic: str,
+    mastery_level: int,
+    next_review: datetime | None,
+    last_review: datetime | None,
+    source_id: int,
+) -> CompatProgressView:
+    # Negative id marks non-persisted compat rows (distinct from progress_trackings PKs).
+    return CompatProgressView(
+        id=-source_id,
+        user_id=user_id,
+        course_id=course_id,
+        topic=topic,
+        mastery_level=mastery_level,
+        next_review=next_review,
+        last_review=last_review,
+    )
+
+
+def create_progress_compat(
+    db: Session,
+    *,
+    user_id: int,
+    course_id: int,
+    topic: str,
+    mastery_level: int = 0,
+    next_review: datetime | None = None,
+) -> ProgressTracking | CompatProgressView:
+    """Compat create: write ConceptMastery; never INSERT ProgressTracking."""
+    if not use_progress_facade():
+        row = ProgressTracking(
+            course_id=course_id,
+            user_id=user_id,
+            topic=topic,
+            mastery_level=mastery_level,
+            next_review=next_review,
+        )
+        db.add(row)
+        db.flush()
+        return row
+
+    now = datetime.now(UTC)
+    cm = _upsert_concept_mastery(
+        db,
+        user_id=user_id,
+        topic=topic,
+        mastery_level=mastery_level,
+        last_review=now,
+    )
+
+    existing_pt = _find_existing_progress_tracking(
+        db, user_id=user_id, course_id=course_id, topic=topic,
+    )
+    if existing_pt:
+        existing_pt.mastery_level = mastery_level
+        if next_review is not None:
+            existing_pt.next_review = next_review
+        existing_pt.last_review = now
+        db.flush()
+        return existing_pt
+
+    return _synthetic_compat_row(
+        user_id=user_id,
+        course_id=course_id,
+        topic=topic,
+        mastery_level=mastery_level,
+        next_review=next_review,
+        last_review=now,
+        source_id=cm.id,
+    )
+
+
+def update_progress_compat(
+    db: Session,
+    *,
+    progress_id: int,
+    user_id: int,
+    course_id: int,
+    topic: str,
+    mastery_level: int = 0,
+    next_review: datetime | None = None,
+) -> ProgressTracking | CompatProgressView:
+    """Compat update: canonical ConceptMastery + optional existing PT row."""
+    if not use_progress_facade():
+        db_progress = (
+            db.query(ProgressTracking)
+            .filter(
+                ProgressTracking.id == progress_id,
+                ProgressTracking.user_id == user_id,
+            )
+            .first()
+        )
+        if not db_progress:
+            raise LookupError("Progress not found")
+        db_progress.course_id = course_id
+        db_progress.topic = topic
+        db_progress.mastery_level = mastery_level
+        if next_review is not None:
+            db_progress.next_review = next_review
+        db.flush()
+        return db_progress
+
+    now = datetime.now(UTC)
+    cm = _upsert_concept_mastery(
+        db,
+        user_id=user_id,
+        topic=topic,
+        mastery_level=mastery_level,
+        last_review=now,
+    )
+
+    db_progress = (
+        db.query(ProgressTracking)
+        .filter(
+            ProgressTracking.id == progress_id,
+            ProgressTracking.user_id == user_id,
+        )
+        .first()
+    )
+    if db_progress:
+        db_progress.course_id = course_id
+        db_progress.topic = topic
+        db_progress.mastery_level = mastery_level
+        if next_review is not None:
+            db_progress.next_review = next_review
+        db_progress.last_review = now
+        db.flush()
+        return db_progress
+
+    return _synthetic_compat_row(
+        user_id=user_id,
+        course_id=course_id,
+        topic=topic,
+        mastery_level=mastery_level,
+        next_review=next_review,
+        last_review=now,
+        source_id=cm.id,
+    )
+
+
+def record_review_compat(
+    db: Session,
+    *,
+    progress_id: int,
+    user_id: int,
+    rating: int,
+) -> dict[str, Any]:
+    """FSRS review — updates FSRSState + ConceptMastery; no new ProgressTracking."""
+    db_progress = (
+        db.query(ProgressTracking)
+        .join(Course, ProgressTracking.course_id == Course.id)
+        .join(World, Course.world_id == World.id)
+        .filter(
+            ProgressTracking.id == progress_id,
+            ProgressTracking.user_id == user_id,
+            World.user_id == user_id,
+        )
+        .first()
+    )
+
+    if db_progress:
+        topic = db_progress.topic
+        course_id = db_progress.course_id
+    elif progress_id < 0 and use_progress_facade():
+        cm = db.query(ConceptMastery).filter(ConceptMastery.id == -progress_id).first()
+        if not cm or cm.user_id != user_id:
+            raise LookupError("Progress not found")
+        topic = cm.concept_id
+        course = (
+            db.query(Course)
+            .join(World, Course.world_id == World.id)
+            .filter(World.user_id == user_id)
+            .first()
+        )
+        if not course:
+            raise LookupError("Course not found")
+        course_id = course.id
+        db_progress = None
+    else:
+        raise LookupError("Progress not found")
+
+    course = db.query(Course).filter(Course.id == course_id).first()
+    if not course:
+        raise LookupError("Course not found")
+
+    fsrs_state_row = (
+        db.query(FSRSState)
+        .filter(
+            FSRSState.user_id == user_id,
+            FSRSState.concept_id == topic,
+        )
+        .first()
+    )
+    existing_fsrs_state = fsrs_state_row.card_data if fsrs_state_row else None
+    result = spaced_repetition.review(existing_fsrs_state, rating)
+
+    cm = _upsert_concept_mastery(
+        db,
+        user_id=user_id,
+        topic=topic,
+        mastery_level=result["mastery_level"],
+        last_review=result["last_review"],
+    )
+
+    fsrs_payload = result["fsrs_state"]
+    if fsrs_state_row is None:
+        fsrs_state_row = FSRSState(
+            user_id=user_id,
+            world_id=course.world_id,
+            concept_id=topic,
+        )
+        db.add(fsrs_state_row)
+
+    fsrs_state_row.card_data = fsrs_payload
+    fsrs_state_row.difficulty = fsrs_payload.get("difficulty")
+    fsrs_state_row.stability = fsrs_payload.get("stability")
+    fsrs_state_row.reps = (fsrs_state_row.reps or 0) + 1
+    fsrs_state_row.last_review = result["last_review"]
+    fsrs_state_row.next_review = result["due"]
+
+    response_id = progress_id
+    if db_progress is not None:
+        db_progress.last_review = result["last_review"]
+        db_progress.next_review = result["due"]
+        db_progress.mastery_level = result["mastery_level"]
+        response_id = db_progress.id
+    else:
+        response_id = -cm.id
+
+    db.flush()
+
+    return {
+        "id": response_id,
+        "topic": topic,
+        "mastery_level": result["mastery_level"],
+        "retrievability": result["retrievability"],
+        "next_review": result["due"],
+        "last_review": result["last_review"],
+    }
+
+
+def list_due_reviews_compat(
+    db: Session,
+    user_id: int,
+    course_id: int | None = None,
+) -> list[ProgressTracking]:
+    """Due reviews — read legacy ProgressTracking rows (compat surface)."""
+    now = datetime.now(UTC)
+    query = (
+        db.query(ProgressTracking)
+        .join(Course, ProgressTracking.course_id == Course.id)
+        .join(World, Course.world_id == World.id)
+        .filter(
+            ProgressTracking.user_id == user_id,
+            ProgressTracking.next_review <= now,
+            World.user_id == user_id,
+        )
+    )
+    if course_id is not None:
+        query = query.filter(ProgressTracking.course_id == course_id)
+    return query.order_by(ProgressTracking.next_review).all()
+
+
+# Global instance for symmetry with teaching_planner / mastery_tracker
+class ProgressFacade:
+    use_progress_facade = staticmethod(use_progress_facade)
+    skip_progress_tracking_writes = staticmethod(skip_progress_tracking_writes)
+    get_lesson_progress = staticmethod(get_lesson_progress)
+    get_canonical_lesson_index = staticmethod(get_canonical_lesson_index)
+    get_course_mastery = staticmethod(get_course_mastery)
+    list_compat_progress_rows = staticmethod(list_compat_progress_rows)
+    create_progress_compat = staticmethod(create_progress_compat)
+    update_progress_compat = staticmethod(update_progress_compat)
+    record_review_compat = staticmethod(record_review_compat)
+    list_due_reviews_compat = staticmethod(list_due_reviews_compat)
+    progress_compat_headers = staticmethod(progress_compat_headers)
+
+
+progress_facade = ProgressFacade()

--- a/backend/services/teaching_planner.py
+++ b/backend/services/teaching_planner.py
@@ -291,7 +291,13 @@ class TeachingPlanner:
         """首次到达某 lesson 时插入 'started' 行（mastery=20）。
 
         [TODO-T5] 不再对 existing 行 += 20。
+        [v1.0.5] ProgressFacade 启用时不再 INSERT ProgressTracking。
         """
+        from backend.services.progress_facade import progress_facade
+
+        if progress_facade.skip_progress_tracking_writes():
+            return
+
         lessons = self._get_lessons(db, course)
         if not lessons or lesson_idx >= len(lessons):
             return

--- a/backend/tests/test_mastery_tracker.py
+++ b/backend/tests/test_mastery_tracker.py
@@ -336,9 +336,10 @@ class TestMasteryTrackerRealDB:
         assert rows[0].mastery_level == 75  # 50 + 25 (concept_mastered delta)
 
     def test_concept_and_lesson_live_in_separate_tables(self, db_session):
-        """[TR-A3] Concept and lesson rows used to share progress_trackings
-        and stomp each other when titles matched; they now live in different
-        tables so collision is structurally impossible."""
+        """[TR-A3] Concept mastery is ConceptMastery; lesson pointer is CourseProgress.
+
+        v1.0.5 ProgressFacade stops new ProgressTracking lesson rows, so a shared
+        title cannot stomp concept mastery via progress_trackings anymore."""
         from backend.services.teaching_planner import teaching_planner
 
         user_id, world_id, course_id = self._seed_user_world_course(db_session)
@@ -368,20 +369,19 @@ class TestMasteryTrackerRealDB:
         teaching_planner._record_lesson_progress(db_session, course, 0)
         db_session.flush()
 
-        # Concept side: ConceptMastery
+        # Concept side: ConceptMastery (canonical)
         cm = db_session.query(ConceptMastery).filter(
             ConceptMastery.user_id == user_id,
             ConceptMastery.concept_id == "递归",
         ).one()
         assert cm.mastery_level == 75
 
-        # Lesson side: ProgressTracking with topic_type='lesson'
+        # Lesson side: no new ProgressTracking row under ProgressFacade
         lesson_rows = db_session.query(ProgressTracking).filter(
             ProgressTracking.course_id == course_id,
             ProgressTracking.topic == "递归",
         ).all()
-        assert len(lesson_rows) == 1
-        assert lesson_rows[0].topic_type == "lesson"
+        assert len(lesson_rows) == 0
 
         # mastery overview pulls only ConceptMastery via course.meta
         overview = mastery_tracker.get_course_mastery(db_session, course_id, user_id)

--- a/backend/tests/test_progress_facade.py
+++ b/backend/tests/test_progress_facade.py
@@ -1,0 +1,179 @@
+"""BEHAVIOR tests for ProgressFacade seam (v1.0.5)."""
+
+import pytest
+
+from backend.models.models import (
+    ConceptMastery,
+    Course,
+    CourseProgress,
+    LessonPlan,
+    ProgressTracking,
+    User,
+    World,
+)
+
+
+def _seed_course_with_lessons(db_session, user_id: int) -> int:
+    world = World(user_id=user_id, name="Facade World", description="test")
+    db_session.add(world)
+    db_session.flush()
+
+    course = Course(
+        world_id=world.id,
+        name="Facade Course",
+        description="test",
+        meta={"generated_lessons": [{"title": "L1", "concepts": ["c1"]}]},
+    )
+    db_session.add(course)
+    db_session.flush()
+
+    db_session.add(
+        LessonPlan(
+            course_id=course.id,
+            order_index=0,
+            title="Lesson A",
+            description="",
+            concepts=["c1"],
+        )
+    )
+    db_session.add(
+        LessonPlan(
+            course_id=course.id,
+            order_index=1,
+            title="Lesson B",
+            description="",
+            concepts=["c2"],
+        )
+    )
+    db_session.add(
+        CourseProgress(
+            course_id=course.id,
+            user_id=user_id,
+            current_lesson_index=1,
+            completed_lesson_ids=[0],
+        )
+    )
+    db_session.commit()
+    return course.id
+
+
+class TestProgressFacadeBehavior:
+    def test_canonical_pointer_matches_textbook_and_archive(
+        self, client, auth_headers, db_session,
+    ):
+        user = db_session.query(User).filter_by(username="testuser").one()
+        course_id = _seed_course_with_lessons(db_session, user.id)
+
+        textbook_resp = client.get(
+            f"/api/courses/{course_id}/progress",
+            headers=auth_headers,
+        )
+        assert textbook_resp.status_code == 200
+        textbook_index = textbook_resp.json()["current_index"]
+
+        archive_resp = client.get(
+            f"/api/progress?course_id={course_id}",
+            headers=auth_headers,
+        )
+        assert archive_resp.status_code == 200
+        assert archive_resp.headers.get("Deprecation") == "true"
+        assert (
+            archive_resp.headers.get("X-Canonical-Current-Lesson-Index")
+            == str(textbook_index)
+        )
+        assert textbook_index == 1
+
+    def test_archive_post_progress_compat_without_new_progress_tracking_row(
+        self, client, auth_headers, db_session,
+    ):
+        user = db_session.query(User).filter_by(username="testuser").one()
+        course_id = _seed_course_with_lessons(db_session, user.id)
+
+        before = db_session.query(ProgressTracking).count()
+        resp = client.post(
+            "/api/progress",
+            json={
+                "course_id": course_id,
+                "topic": "new_concept",
+                "mastery_level": 55,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["topic"] == "new_concept"
+        assert payload["mastery_level"] == 55
+        assert resp.headers.get("Deprecation") == "true"
+
+        after = db_session.query(ProgressTracking).count()
+        assert after == before
+
+        cm = (
+            db_session.query(ConceptMastery)
+            .filter(
+                ConceptMastery.user_id == user.id,
+                ConceptMastery.concept_id == "new_concept",
+            )
+            .one()
+        )
+        assert cm.mastery_level == 55
+
+    def test_teaching_planner_advance_does_not_insert_progress_tracking(
+        self, client, auth_headers, db_session,
+    ):
+        user = db_session.query(User).filter_by(username="testuser").one()
+        course_id = _seed_course_with_lessons(db_session, user.id)
+
+        before = db_session.query(ProgressTracking).count()
+        resp = client.post(
+            f"/api/courses/{course_id}/advance",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        after = db_session.query(ProgressTracking).count()
+        assert after == before
+
+    def test_rollback_flag_restores_progress_tracking_insert(
+        self, client, auth_headers, db_session, monkeypatch,
+    ):
+        from backend.core.config import get_settings
+
+        monkeypatch.setenv("USE_PROGRESS_FACADE", "false")
+        get_settings.cache_clear()
+
+        user = db_session.query(User).filter_by(username="testuser").one()
+        course_id = _seed_course_with_lessons(db_session, user.id)
+
+        before = db_session.query(ProgressTracking).count()
+        resp = client.post(
+            "/api/progress",
+            json={
+                "course_id": course_id,
+                "topic": "legacy_topic",
+                "mastery_level": 40,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        after = db_session.query(ProgressTracking).count()
+        assert after == before + 1
+
+        get_settings.cache_clear()
+
+    def test_handlers_delegate_to_facade_not_direct_orm_insert(self):
+        import inspect
+
+        from backend.api.routes import archive as archive_routes
+
+        source = inspect.getsource(archive_routes.create_progress)
+        assert "progress_facade.create_progress_compat" in source
+        assert "ProgressTracking(" not in source
+
+        textbook_source = open(
+            __file__.replace("test_progress_facade.py", "../api/routes/textbook.py"),
+            encoding="utf-8",
+        ).read()
+        assert "progress_facade.get_lesson_progress" in textbook_source
+        assert "teaching_planner.get_progress" not in textbook_source.split(
+            "get_course_progress",
+        )[1].split("def advance_lesson")[0]


### PR DESCRIPTION
Closes #254

## Seam
ProgressFacade (v1.0.5 seam A)

## 不改什么
- textbook canonical URL (`GET /api/courses/{id}/progress`, `/mastery`)
- ConceptMastery / CourseProgress 权威地位
- archive 5 个 `/progress*` 兼容端点（未删除）
- 前端、archive.py 拆分、report/profile 迁移

## 本次改动
- 新增 `backend/services/progress_facade.py`
- textbook / archive progress handler 委托 facade
- `POST /api/progress` 兼容 200，但不再 INSERT ProgressTracking
- `USE_PROGRESS_FACADE=false` 回退开关

## HARD 证据
- archive `create_progress` 无 `ProgressTracking(` 直写
- textbook `get_course_progress` 经 `progress_facade.get_lesson_progress`

## BEHAVIOR 证据
- `pytest backend/tests/test_progress_facade.py -v`（5 passed 本地 + CI backend-test）

## 回退方案
- `.env` 设 `USE_PROGRESS_FACADE=false` 或 revert 本 PR

## 是否影响下一个 seam
- 为 archive.py split 铺路；无破坏性依赖
