### PR TITLE
refactor(v1.0.5): Seam A2-2 — lesson pointer 读单源化

### DIFF
--- a/backend/services/progress_facade.py
+++ b/backend/services/progress_facade.py
@@ -64,8 +64,7 @@ def progress_compat_headers(course_id: int | None = None) -> dict[str, str]:
 
 def get_lesson_progress(db: Session, course: Course, user_id: int) -> dict[str, Any]:
     """Canonical lesson progress (CourseProgress / LessonPlan)."""
-    _ = user_id  # caller supplies for auth symmetry; planner reads course.world
-    return teaching_planner.get_progress(db, course)
+    return teaching_planner.get_progress(db, course, user_id=user_id)
 
 
 def get_canonical_lesson_index(db: Session, course_id: int, user_id: int) -> int:

--- a/backend/services/prompt_builder/modules/course_content.py
+++ b/backend/services/prompt_builder/modules/course_content.py
@@ -105,7 +105,7 @@ class CourseContentModule(MemoryModule):
         Tries LessonPlan table first, falls back to course.meta.
         """
         # New data source: LessonPlan rows
-        from backend.models.models import CourseProgress, LessonPlan
+        from backend.models.models import LessonPlan
 
         lesson_rows = db.query(LessonPlan).filter(
             LessonPlan.course_id == course.id,
@@ -122,17 +122,10 @@ class CourseContentModule(MemoryModule):
                 for lp in lesson_rows
             ]
 
-            # Progress from CourseProgress table
-            current_idx = 0
-            if user_id:
-                progress = db.query(CourseProgress).filter(
-                    CourseProgress.course_id == course.id,
-                    CourseProgress.user_id == user_id,
-                ).first()
-                if progress:
-                    current_idx = progress.current_lesson_index or 0
+            from backend.services.teaching_planner import teaching_planner
 
-            return lessons, current_idx
+            prog = teaching_planner.get_progress(db, course, user_id=user_id)
+            return lessons, prog["current_index"]
 
         # Backward compat: course.meta
         lessons = meta.get("generated_lessons", [])

--- a/backend/services/teaching_planner.py
+++ b/backend/services/teaching_planner.py
@@ -146,8 +146,11 @@ class TeachingPlanner:
 
         return None
 
-    def get_progress(self, db: Session, course: Course) -> dict:
+    def get_progress(self, db: Session, course: Course, user_id: int | None = None) -> dict:
         """获取课程教学进度
+
+        Args:
+            user_id: 显式用户 ID（路由层已知时传入）
 
         Returns:
             {
@@ -172,8 +175,8 @@ class TeachingPlanner:
                 "course_completed": False,
             }
 
-        user_id = self._get_user_id(course)
-        if user_id is None:
+        uid = user_id if user_id is not None else self._get_user_id(course)
+        if uid is None:
             return {
                 "total_lessons": len(lessons),
                 "current_index": 0,
@@ -184,8 +187,8 @@ class TeachingPlanner:
                 "course_completed": False,
             }
 
-        current_idx = self._get_current_index(db, course, user_id)
-        completed_list = self._get_completed(db, course, user_id)
+        current_idx = self._get_current_index(db, course, uid)
+        completed_list = self._get_completed(db, course, uid)
         completed = set(completed_list)
 
         # current_idx 超出范围时 clamp

--- a/backend/tests/test_lesson_pointer_single_source.py
+++ b/backend/tests/test_lesson_pointer_single_source.py
@@ -395,3 +395,38 @@ class TestLearningEntryAlignment:
             CourseProgress.user_id == user.id,
         ).one()
         assert cp.current_lesson_index == api_index == 1
+
+
+class TestA22CanonicalLessonReads:
+    def test_course_content_uses_planner_not_direct_course_progress(self):
+        source = (
+            ROOT / "backend/services/prompt_builder/modules/course_content.py"
+        ).read_text(encoding="utf-8")
+        start = source.index("def _get_lessons_and_progress")
+        rest = source[start + 1:]
+        next_def = rest.index("\n    def ")
+        chunk = source[start: start + 1 + next_def]
+        assert "query(CourseProgress)" not in chunk
+
+    def test_course_content_honors_course_progress_over_stale_meta(
+        self, db_session,
+    ):
+        from backend.services.prompt_builder.modules.course_content import (
+            CourseContentModule,
+        )
+
+        user, course = _seed_dual_source_course(
+            db_session, cp_index=1, meta_index=5,
+        )
+        db_session.commit()
+
+        module = CourseContentModule()
+        rendered = module.assemble({
+            "db": db_session,
+            "course_id": course.id,
+        })
+
+        assert "第2课: Lesson 1" in rendered
+        assert "[当前章节]" in rendered
+        assert "第1课: Lesson 0" in rendered
+        assert "已完成" in rendered


### PR DESCRIPTION
## Overview
Seam A2-2：将 lesson pointer **读路径**收敛到 `teaching_planner.get_progress`，消除 `course_content` 等对 `CourseProgress` 的旁路查询；`progress_facade.get_lesson_progress` 显式传入 `user_id`。

## Change List
- `backend/services/teaching_planner.py`：`get_progress` 支持可选 `user_id`
- `backend/services/progress_facade.py`：canonical 读委托 planner 并传入 user_id
- `backend/services/prompt_builder/modules/course_content.py`：`_get_lessons_and_progress` 委托 planner
- `backend/tests/test_lesson_pointer_single_source.py`：A2-2 HARD + 双源行为测试

## Self-Check
- [x] 已运行相关测试（`test_lesson_pointer_single_source.py`）
- [x] 已评估回归风险（仅读路径，HTTP schema 不变）
- [x] 已检查兼容性（legacy meta fallback 仍由 planner 处理）
- [x] 无无关改动混入
- [x] 未在业务层/脚本中直接赋值 User LLM 字段

## Reviewer Focus
- [ ] `course_content.py` 的 `_get_lessons_and_progress` 无 `query(CourseProgress)` 旁路
- [ ] CourseProgress 与 stale meta 并存时，prompt 渲染与 API progress 一致

### 自查项 - LLM 用户配置写入规范
- [x] 未直接赋值 user.default_provider / model / encrypted_api_key / llm_provider_settings / temperature / max_tokens
- [x] 所有LLM配置更新统一使用 update_provider_settings / update_generation_params
- [x] 仅 tests 目录 fixture 允许裸写

## Linked Issues
Closes #259