### PR TITLE
refactor(v1.0.5): Seam A2-3 — 停止 lesson 相关旧 PT 读取

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,8 +20,5 @@
 - [ ] 所有LLM配置更新统一使用 update_provider_settings / update_generation_params
 - [ ] 仅 tests 目录 fixture 允许裸写，业务代码、scripts 不允许直接ORM赋值
 
-## Linked Issues
-Closes #N
-
-> 必须使用自动闭合关键字：`Closes #N` / `Fixes #N` / `Resolves #N`。
-> 仅写 `Related to #N` 不会自动闭合 issue。
+## Linked Issues（可选）
+<!-- 有 tracking issue 时可写 Closes #N / Fixes #N / Resolves #N；无 issue 的小步 PR 可留空 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,22 +7,6 @@ on:
     branches: [main]
 
 jobs:
-  pr-issue-closure:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Enforce auto-close issue keyword
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = context.payload.pull_request.body || "";
-            const autoCloseRef = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#\d+\b/i;
-            if (!autoCloseRef.test(body)) {
-              core.setFailed(
-                "PR description must include an auto-closing issue reference such as `Closes #130` / `Fixes #130` / `Resolves #130`. `Related to #130` alone will not close the issue."
-              );
-            }
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,7 @@ Owner创建Issue → Owner 标记 approved
 
 - **单一职责**：一个 PR 只做一件事
 - **体量控制**：尽量 300 行以内
-- **必须关联 Issue**：`Closes #N`
-- **禁止只写**：`Related to #N`（不会自动闭合 issue）
+- **关联 Issue（可选）**：有 tracking issue 时在 PR 中写 `Closes #N`；小步 seam PR 可不建 issue
 - **PR 描述包含**：
   - 变更概述
   - 改动清单（文件 + 说明）

--- a/backend/api/routes/archive.py
+++ b/backend/api/routes/archive.py
@@ -693,14 +693,13 @@ def _build_world_response(world: World, db: Session, current_user_id: int = None
             progress = None
             icon = ""  # 默认图标
 
-            # 如果提供了 user_id，获取课程进度
+            # 如果提供了 user_id，获取课程进度（canonical · A2-3）
             if current_user_id:
-                course_progress = db.query(ProgressTracking).filter(
-                    ProgressTracking.course_id == course.id,
-                    ProgressTracking.user_id == current_user_id
-                ).first()
-                if course_progress:
-                    progress = course_progress.mastery_level / 100.0
+                from backend.services.progress_facade import progress_facade
+
+                progress = progress_facade.get_course_lesson_progress_fraction(
+                    db, course, current_user_id,
+                )
 
             course_list.append(CourseResponse(
                 id=course.id,

--- a/backend/api/routes/save.py
+++ b/backend/api/routes/save.py
@@ -164,7 +164,7 @@ def _build_full_save_data(
             for f in facts
         ]
 
-    # Progress snapshot  [TODO-S4] Include both ConceptMastery and lesson progress
+    # Progress snapshot  [TODO-S4 / A2-3b] export-only; restore 尚未写回 DB
     progress_snapshot: dict = {"concepts": [], "lessons": []}
 
     # Concept mastery (cross-world)
@@ -178,7 +178,7 @@ def _build_full_save_data(
         for c in concept_rows
     ]
 
-    # Lesson progress (per-course)
+    # Lesson progress export (legacy PT rows) — canonical 化留 A2-3b；当前不参与 UI 展示
     if course_id:
         progress_list = (
             db.query(ProgressTracking)
@@ -235,16 +235,22 @@ def _build_checkpoint_response(cp: Checkpoint, db: Session, user_id: int) -> Che
 
     date = cp.created_at.strftime("%Y-%m-%d %H:%M") if cp.created_at else None
 
+    # masteryPercent：checkpoint 列表展示用 **课节完成度**（非概念掌握度均值）
     mastery = None
     course_id = state.get("course_id")
     if course_id:
-        progress_list = db.query(ProgressTracking).filter(
-            ProgressTracking.course_id == course_id,
-            ProgressTracking.user_id == user_id,
-        ).all()
-        if progress_list:
-            total = sum(p.mastery_level for p in progress_list)
-            mastery = total / len(progress_list) / 100.0
+        course = (
+            db.query(Course)
+            .join(World, Course.world_id == World.id)
+            .filter(Course.id == course_id, World.user_id == user_id)
+            .first()
+        )
+        if course:
+            from backend.services.progress_facade import progress_facade
+
+            mastery = progress_facade.get_course_lesson_progress_fraction(
+                db, course, user_id,
+            )
 
     preview = _get_last_message_preview(db, cp.session_id) if cp.session_id else None
 

--- a/backend/services/progress_facade.py
+++ b/backend/services/progress_facade.py
@@ -67,6 +67,18 @@ def get_lesson_progress(db: Session, course: Course, user_id: int) -> dict[str, 
     return teaching_planner.get_progress(db, course, user_id=user_id)
 
 
+def get_course_lesson_progress_fraction(
+    db: Session,
+    course: Course,
+    user_id: int,
+) -> float | None:
+    """0.0–1.0 lesson completion fraction for list/display surfaces (A2-3)."""
+    prog = get_lesson_progress(db, course, user_id)
+    if prog.get("total_lessons", 0) == 0:
+        return None
+    return round(prog.get("progress_pct", 0.0) / 100.0, 4)
+
+
 def get_canonical_lesson_index(db: Session, course_id: int, user_id: int) -> int:
     course = (
         db.query(Course)
@@ -424,6 +436,7 @@ class ProgressFacade:
     use_progress_facade = staticmethod(use_progress_facade)
     skip_progress_tracking_writes = staticmethod(skip_progress_tracking_writes)
     get_lesson_progress = staticmethod(get_lesson_progress)
+    get_course_lesson_progress_fraction = staticmethod(get_course_lesson_progress_fraction)
     get_canonical_lesson_index = staticmethod(get_canonical_lesson_index)
     get_course_mastery = staticmethod(get_course_mastery)
     list_compat_progress_rows = staticmethod(list_compat_progress_rows)

--- a/backend/tests/test_lesson_pointer_single_source.py
+++ b/backend/tests/test_lesson_pointer_single_source.py
@@ -430,3 +430,114 @@ class TestA22CanonicalLessonReads:
         assert "[当前章节]" in rendered
         assert "第1课: Lesson 0" in rendered
         assert "已完成" in rendered
+
+
+class TestA23CanonicalLessonReads:
+    def test_world_list_course_progress_matches_canonical_api(
+        self, client, auth_headers, db_session,
+    ):
+        user = db_session.query(User).filter_by(username="testuser").one()
+
+        world = World(user_id=user.id, name="World List", description="")
+        db_session.add(world)
+        db_session.flush()
+
+        course = Course(world_id=world.id, name="Listed Course", meta={})
+        db_session.add(course)
+        db_session.flush()
+
+        for i, title in enumerate(["L0", "L1", "L2"]):
+            db_session.add(
+                LessonPlan(
+                    course_id=course.id,
+                    order_index=i,
+                    title=title,
+                    concepts=[f"c{i}"],
+                )
+            )
+        db_session.add(
+            CourseProgress(
+                course_id=course.id,
+                user_id=user.id,
+                current_lesson_index=1,
+                completed_lesson_ids=[0],
+            )
+        )
+        db_session.commit()
+
+        canonical = client.get(
+            f"/api/courses/{course.id}/progress",
+            headers=auth_headers,
+        )
+        assert canonical.status_code == 200
+        expected_fraction = round(canonical.json()["progress_pct"] / 100.0, 4)
+
+        worlds = client.get("/api/worlds", headers=auth_headers)
+        assert worlds.status_code == 200
+        world_payload = next(w for w in worlds.json() if w["id"] == world.id)
+        listed = next(c for c in world_payload["courses"] if c["id"] == course.id)
+        assert listed["progress"] == expected_fraction
+
+    def test_archive_world_builder_has_no_progress_tracking_lesson_read(self):
+        source = (ROOT / "backend/api/routes/archive.py").read_text(encoding="utf-8")
+        start = source.index("def _build_world_response")
+        rest = source[start + 1:]
+        next_def = rest.index("\ndef ")
+        chunk = source[start: start + 1 + next_def]
+        assert "ProgressTracking" not in chunk
+
+    def test_save_checkpoint_mastery_percent_uses_canonical_progress(
+        self, client, auth_headers, db_session,
+    ):
+        user = db_session.query(User).filter_by(username="testuser").one()
+
+        world = World(user_id=user.id, name="Save World", description="")
+        db_session.add(world)
+        db_session.flush()
+
+        course = Course(world_id=world.id, name="Save Course", meta={})
+        db_session.add(course)
+        db_session.flush()
+
+        for i, title in enumerate(["L0", "L1"]):
+            db_session.add(
+                LessonPlan(
+                    course_id=course.id,
+                    order_index=i,
+                    title=title,
+                    concepts=[f"c{i}"],
+                )
+            )
+        db_session.add(
+            CourseProgress(
+                course_id=course.id,
+                user_id=user.id,
+                current_lesson_index=1,
+                completed_lesson_ids=[0],
+            )
+        )
+        db_session.commit()
+
+        start = client.post(f"/api/courses/{course.id}/start", headers=auth_headers)
+        assert start.status_code == 200
+        session_id = start.json()["session_id"]
+
+        checkpoint = client.post(
+            "/api/checkpoints",
+            json={
+                "world_id": world.id,
+                "save_name": "a2-canonical",
+                "session_id": session_id,
+            },
+            headers=auth_headers,
+        )
+        assert checkpoint.status_code == 200
+        assert checkpoint.json()["masteryPercent"] == 0.5
+
+    def test_save_checkpoint_display_has_no_progress_tracking_read(self):
+        source = (ROOT / "backend/api/routes/save.py").read_text(encoding="utf-8")
+        start = source.index("def _build_checkpoint_response")
+        rest = source[start + 1:]
+        next_def = rest.index("\ndef ")
+        chunk = source[start: start + 1 + next_def]
+        assert "query(ProgressTracking)" not in chunk


### PR DESCRIPTION
## Overview
Seam A2-3：world 列表与 checkpoint 展示不再通过 ProgressTracking 表达 lesson 进度，改读 canonical `CourseProgress`/`LessonPlan`（经 `progress_facade`）。

**A2-3b 延后**：`_build_full_save_data` 的 `progress_snapshot[lessons]` 仍导出 legacy PT 行（restore 未实现、不参与当前 UI）。

## Change List
- `backend/services/progress_facade.py`：新增 `get_course_lesson_progress_fraction`
- `backend/api/routes/archive.py`：`_build_world_response` 课程 progress 改 canonical
- `backend/api/routes/save.py`：`_build_checkpoint_response` masteryPercent 改课节完成度
- `backend/tests/test_lesson_pointer_single_source.py`：A2-3 行为 + HARD grep 测试

## Self-Check
- [x] 已运行相关测试（`test_lesson_pointer_single_source.py`）
- [x] 已评估回归风险（仅展示层读路径）
- [x] 已检查兼容性（无 CourseProgress 时返回 None/空）
- [x] 无无关改动混入
- [x] 未在业务层/脚本中直接赋值 User LLM 字段

## Reviewer Focus
- [ ] `_build_world_response` 区块无 ProgressTracking lesson 读
- [ ] checkpoint masteryPercent 与课节完成度 API 一致（非概念掌握度均值）

### 自查项 - LLM 用户配置写入规范
- [x] 未直接赋值 user.default_provider / model / encrypted_api_key / llm_provider_settings / temperature / max_tokens
- [x] 所有LLM配置更新统一使用 update_provider_settings / update_generation_params
- [x] 仅 tests 目录 fixture 允许裸写

## Linked Issues
Closes #262