### PR TITLE
refactor(v1.0.5): remove lesson ProgressTracking writer and export canonical save progress

### DIFF
--- a/backend/api/routes/save.py
+++ b/backend/api/routes/save.py
@@ -16,7 +16,6 @@ from backend.models.models import (
     Course,
     LearnerProfile,
     MemoryFact,
-    ProgressTracking,
     # Phase 1.5 DD1: TeacherPersona 已删除，相关功能合并到 Character
     User,
     World,
@@ -164,8 +163,8 @@ def _build_full_save_data(
             for f in facts
         ]
 
-    # Progress snapshot  [TODO-S4 / A2-3b] export-only; restore 尚未写回 DB
-    progress_snapshot: dict = {"concepts": [], "lessons": []}
+    # Progress snapshot. Lesson state is exported from canonical CourseProgress/LessonPlan.
+    progress_snapshot: dict = {"concepts": [], "lessons": {}}
 
     # Concept mastery (cross-world)
     concept_rows = (
@@ -178,20 +177,12 @@ def _build_full_save_data(
         for c in concept_rows
     ]
 
-    # Lesson progress export (legacy PT rows) — canonical 化留 A2-3b；当前不参与 UI 展示
-    if course_id:
-        progress_list = (
-            db.query(ProgressTracking)
-            .filter(
-                ProgressTracking.course_id == int(course_id),
-                ProgressTracking.user_id == user_id,
-            )
-            .all()
-        )
-        progress_snapshot["lessons"] = [
-            {"topic": p.topic, "mastery_level": p.mastery_level}
-            for p in progress_list
-        ]
+    # Lesson progress export is canonical read-only snapshot data; restore still owns writeback.
+    progress_snapshot["lessons"] = _build_lesson_progress_snapshot(
+        db,
+        user_id=user_id,
+        course_id=course_id,
+    )
 
     return SaveFileManager.build_save_data(
         checkpoint_id=checkpoint.id,
@@ -220,6 +211,51 @@ def _get_checkpoint_state(checkpoint: Checkpoint) -> dict:
             checkpoint.file_path,
         )
     return checkpoint.state or {}
+
+
+def _build_lesson_progress_snapshot(
+    db: Session,
+    *,
+    user_id: int,
+    course_id: int | None,
+) -> dict:
+    if not course_id:
+        return {}
+
+    course = (
+        db.query(Course)
+        .join(World, Course.world_id == World.id)
+        .filter(
+            Course.id == int(course_id),
+            World.user_id == user_id,
+        )
+        .first()
+    )
+    if not course:
+        return {}
+
+    from backend.services.progress_facade import progress_facade
+
+    progress = progress_facade.get_lesson_progress(db, course, user_id)
+    lessons = progress.get("lessons", [])
+    return {
+        "current_index": progress.get("current_index", 0),
+        "completed_lesson_ids": [
+            idx for idx, lesson in enumerate(lessons)
+            if lesson.get("_status") == "completed"
+        ],
+        "total_lessons": progress.get("total_lessons", 0),
+        "progress_pct": progress.get("progress_pct", 0.0),
+        "course_completed": progress.get("course_completed", False),
+        "items": [
+            {
+                "id": lesson.get("id"),
+                "title": lesson.get("title", ""),
+                "status": lesson.get("_status", "pending"),
+            }
+            for lesson in lessons
+        ],
+    }
 
 
 def _build_checkpoint_response(cp: Checkpoint, db: Session, user_id: int) -> CheckpointResponse:

--- a/backend/services/teaching_planner.py
+++ b/backend/services/teaching_planner.py
@@ -1,46 +1,31 @@
-"""Teaching Planner Service
+"""Teaching Planner service.
 
-管理课程教学进度：当前章节、完成状态、自动推进。
-
-Phase 3 Step 3: 课程感知教学集成
-
-数据源迁移：从 course.meta JSON → LessonPlan 表 + CourseProgress 表
-- 课程列表：LessonPlan 行（按 order_index 排序）
-- 进度状态：CourseProgress 行（current_lesson_index, completed_lesson_ids）
-- 向后兼容：如 LessonPlan 行为空，回退读 course.meta
+Canonical lesson-pointer storage:
+- Lesson content: `LessonPlan` rows, with `course.meta["generated_lessons"]` as fallback
+- Lesson progress: `CourseProgress`, with legacy `course.meta` fields as fallback
 """
 
 import logging
-from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
-from backend.core.config import get_settings
-from backend.models.models import Course, CourseProgress, LessonPlan, ProgressTracking
+from backend.models.models import Course, CourseProgress, LessonPlan
 
 logger = logging.getLogger(__name__)
 
 
 class TeachingPlanner:
-    """教学进度管理器
-
-    职责：
-    - 获取/设置当前教学章节
-    - 推进到下一课（手动或自动）
-    - 计算整体完成度
-    """
+    """Manage lesson progression for a course."""
 
     def _get_lessons(self, db: Session, course: Course) -> list[dict]:
-        """获取课程的所有章节（新数据源优先，兼容旧数据）
-
-        Returns:
-            list of lesson dicts with keys: title, description, order, concepts, prerequisites
-        """
-        # 新数据源：LessonPlan 表
-        lesson_rows = db.query(LessonPlan).filter(
-            LessonPlan.course_id == course.id,
-        ).order_by(LessonPlan.order_index).all()
+        """Return lesson content from canonical rows, falling back to legacy meta."""
+        lesson_rows = (
+            db.query(LessonPlan)
+            .filter(LessonPlan.course_id == course.id)
+            .order_by(LessonPlan.order_index)
+            .all()
+        )
 
         if lesson_rows:
             return [
@@ -50,42 +35,38 @@ class TeachingPlanner:
                     "order": lp.order_index,
                     "concepts": lp.concepts or [],
                     "prerequisites": lp.prerequisites or [],
-                    "id": lp.id,  # include DB id for reference
+                    "id": lp.id,
                 }
                 for lp in lesson_rows
             ]
 
-        # 向后兼容：旧数据从 course.meta 读取
         if course.meta and course.meta.get("generated_lessons"):
             return course.meta["generated_lessons"]
 
         return []
 
     def _get_progress_record(self, db: Session, course: Course, user_id: int) -> CourseProgress | None:
-        """获取 CourseProgress 行"""
-        return db.query(CourseProgress).filter(
-            CourseProgress.course_id == course.id,
-            CourseProgress.user_id == user_id,
-        ).first()
+        return (
+            db.query(CourseProgress)
+            .filter(
+                CourseProgress.course_id == course.id,
+                CourseProgress.user_id == user_id,
+            )
+            .first()
+        )
 
     def _get_current_index(self, db: Session, course: Course, user_id: int) -> int:
-        """获取当前章节索引（新数据源优先，兼容旧数据）"""
         progress = self._get_progress_record(db, course, user_id)
         if progress:
             return progress.current_lesson_index or 0
-
-        # 向后兼容
         if course.meta:
             return course.meta.get("current_lesson_index", 0)
         return 0
 
     def _get_completed(self, db: Session, course: Course, user_id: int) -> list[int]:
-        """获取已完成的章节索引列表"""
         progress = self._get_progress_record(db, course, user_id)
         if progress:
             return progress.completed_lesson_ids or []
-
-        # 向后兼容
         if course.meta:
             return course.meta.get("completed_lessons", [])
         return []
@@ -99,36 +80,27 @@ class TeachingPlanner:
         current_index: int,
         completed_ids: list[int] | None = None,
     ) -> None:
-        """唯一 lesson pointer 写入口。
-
-        - 有 CourseProgress 行 → 只写表（不写 course.meta 指针字段）
-        - 无行 → legacy fallback 写 course.meta
-        """
+        """Single write gateway for lesson-pointer state."""
         progress = self._get_progress_record(db, course, user_id)
         if progress:
             progress.current_lesson_index = current_index
             if completed_ids is not None:
                 progress.completed_lesson_ids = completed_ids
-        else:
-            if not course.meta:
-                course.meta = {}
-            course.meta["current_lesson_index"] = current_index
-            if completed_ids is not None:
-                course.meta["completed_lessons"] = completed_ids
-            flag_modified(course, "meta")
+            return
+
+        if not course.meta:
+            course.meta = {}
+        course.meta["current_lesson_index"] = current_index
+        if completed_ids is not None:
+            course.meta["completed_lessons"] = completed_ids
+        flag_modified(course, "meta")
 
     def _get_user_id(self, course: Course) -> int | None:
-        """从 course → world → user 获取 user_id"""
         if course.world:
             return course.world.user_id
         return None
 
     def get_current_lesson(self, db: Session, course: Course) -> dict | None:
-        """获取当前课程的教学章节信息
-
-        Returns:
-            当前章节 dict（含 title, description, concepts 等），或 None
-        """
         lessons = self._get_lessons(db, course)
         if not lessons:
             return None
@@ -143,26 +115,9 @@ class TeachingPlanner:
             lesson["_index"] = current_idx
             lesson["_total"] = len(lessons)
             return lesson
-
         return None
 
     def get_progress(self, db: Session, course: Course, user_id: int | None = None) -> dict:
-        """获取课程教学进度
-
-        Args:
-            user_id: 显式用户 ID（路由层已知时传入）
-
-        Returns:
-            {
-                "total_lessons": int,
-                "current_index": int,
-                "completed_lessons": int,
-                "progress_pct": float,
-                "current_lesson": dict | None,
-                "lessons": list[dict],
-                "course_completed": bool,
-            }
-        """
         lessons = self._get_lessons(db, course)
         if not lessons:
             return {
@@ -188,10 +143,8 @@ class TeachingPlanner:
             }
 
         current_idx = self._get_current_index(db, course, uid)
-        completed_list = self._get_completed(db, course, uid)
-        completed = set(completed_list)
+        completed = set(self._get_completed(db, course, uid))
 
-        # current_idx 超出范围时 clamp
         if current_idx >= len(lessons):
             current_idx = max(0, len(lessons) - 1)
 
@@ -200,15 +153,14 @@ class TeachingPlanner:
         pct = (done / total * 100) if total > 0 else 0.0
 
         current_lesson = None
-        if lessons and 0 <= current_idx < len(lessons):
+        if 0 <= current_idx < len(lessons):
             current_lesson = dict(lessons[current_idx])
             current_lesson["_index"] = current_idx
             current_lesson["_status"] = "completed" if current_idx in completed else "current"
 
-        # 给每个 lesson 加状态
         lesson_list = []
-        for i, l in enumerate(lessons):
-            item = dict(l)
+        for i, lesson in enumerate(lessons):
+            item = dict(lesson)
             if i in completed:
                 item["_status"] = "completed"
             elif i == current_idx:
@@ -217,8 +169,6 @@ class TeachingPlanner:
                 item["_status"] = "pending"
             lesson_list.append(item)
 
-        course_completed = total > 0 and done >= total
-
         return {
             "total_lessons": total,
             "current_index": current_idx,
@@ -226,14 +176,11 @@ class TeachingPlanner:
             "progress_pct": round(pct, 1),
             "current_lesson": current_lesson,
             "lessons": lesson_list,
-            "course_completed": course_completed,
+            "course_completed": total > 0 and done >= total,
         }
 
     def advance_lesson(self, db: Session, course: Course) -> dict:
-        """推进到下一课
-
-        Marks current lesson as completed and moves to next.
-        """
+        """Mark the current lesson completed and move to the next lesson."""
         lessons = self._get_lessons(db, course)
         if not lessons:
             return {"error": "课程无生成内容"}
@@ -243,16 +190,12 @@ class TeachingPlanner:
             return {"error": "无法确定用户"}
 
         current_idx = self._get_current_index(db, course, user_id)
-        completed_list = self._get_completed(db, course, user_id)
-        completed = set(completed_list)
-
-        # 标记当前为完成
+        completed = set(self._get_completed(db, course, user_id))
         completed.add(current_idx)
 
-        # 推进到下一课（不超出范围）
         next_idx = current_idx + 1
         if next_idx >= len(lessons):
-            next_idx = len(lessons) - 1  # stay on last lesson
+            next_idx = len(lessons) - 1
 
         self._set_lesson_progress(
             db,
@@ -261,34 +204,24 @@ class TeachingPlanner:
             current_index=next_idx,
             completed_ids=sorted(completed),
         )
-
-        # 记录到 ProgressTracking
-        self._record_lesson_progress(db, course, next_idx)
-
         db.flush()
 
         logger.info(
-            "Course %d: lesson %d → %d (completed: %s)",
-            course.id, current_idx, next_idx, sorted(completed),
+            "Course %d: lesson %d -> %d (completed: %s)",
+            course.id,
+            current_idx,
+            next_idx,
+            sorted(completed),
         )
-
         return self.get_progress(db, course)
 
     def set_lesson(self, db: Session, course: Course, lesson_index: int) -> dict:
-        """手动设置当前教学章节
-
-        Args:
-            lesson_index: 目标章节索引 (0-based)
-
-        Returns:
-            更新后的进度 dict
-        """
+        """Move the lesson pointer without mutating completion history."""
         lessons = self._get_lessons(db, course)
         if not lessons:
             return {"error": "课程无生成内容"}
-
         if lesson_index < 0 or lesson_index >= len(lessons):
-            return {"error": f"章节索引超出范围 (0-{len(lessons)-1})"}
+            return {"error": f"章节索引超出范围 (0-{len(lessons) - 1})"}
 
         user_id = self._get_user_id(course)
         if user_id is None:
@@ -300,56 +233,10 @@ class TeachingPlanner:
             user_id,
             current_index=lesson_index,
         )
-
-        self._record_lesson_progress(db, course, lesson_index)
         db.flush()
 
         logger.info("Course %d: manually set to lesson %d", course.id, lesson_index)
-
         return self.get_progress(db, course)
-
-    def _record_lesson_progress(self, db: Session, course: Course, lesson_idx: int):
-        """首次到达某 lesson 时插入 'started' 行（mastery=20）。
-
-        [TODO-T5] 不再对 existing 行 += 20。
-        [v1.0.5] ProgressFacade 启用时不再 INSERT ProgressTracking。
-        """
-        from backend.services.progress_facade import progress_facade
-
-        if progress_facade.skip_progress_tracking_writes():
-            return
-
-        lessons = self._get_lessons(db, course)
-        if not lessons or lesson_idx >= len(lessons):
-            return
-
-        lesson = lessons[lesson_idx]
-        topic = lesson.get("title", f"Lesson {lesson_idx + 1}")
-
-        # [TODO-T3] filter by topic_type so a lesson title that happens to
-        # equal a concept name doesn't collide with mastery_tracker rows.
-        existing = db.query(ProgressTracking).filter(
-            ProgressTracking.course_id == course.id,
-            ProgressTracking.topic == topic,
-            ProgressTracking.topic_type == "lesson",
-        ).first()
-
-        if existing:
-            # Already started — just refresh last_review timestamp.
-            existing.last_review = datetime.now(UTC)
-            return
-
-        # [TODO-T9] initial mastery for a freshly-started lesson is config-driven
-        initial = get_settings().learning_system["mastery"]["lesson_started_initial"]
-        tracking = ProgressTracking(
-            course_id=course.id,
-            user_id=course.world.user_id if course.world else None,
-            topic=topic,
-            topic_type="lesson",
-            mastery_level=initial,
-            last_review=datetime.now(UTC),
-        )
-        db.add(tracking)
 
     def try_auto_advance_if_mastered(
         self,
@@ -357,10 +244,7 @@ class TeachingPlanner:
         course: Course,
         user_id: int,
     ) -> tuple[bool, int | None]:
-        """唯一 auto-advance 事务入口（TeachingPlanner 完整边界）。
-
-        读取当前课节 → 判定 concepts 是否 mastered → 推进并落库。
-        """
+        """Advance once when all concepts in the current lesson are mastered."""
         from backend.services.mastery_tracker import mastery_tracker
 
         lessons = self._get_lessons(db, course)
@@ -390,16 +274,15 @@ class TeachingPlanner:
             current_index=next_idx,
             completed_ids=sorted(completed),
         )
-        self._record_lesson_progress(db, course, next_idx)
         db.flush()
 
         logger.info(
-            "Auto-advanced course %d: lesson %d → %d",
-            course.id, current_idx, next_idx,
+            "Auto-advanced course %d: lesson %d -> %d",
+            course.id,
+            current_idx,
+            next_idx,
         )
         return True, next_idx
 
 
-# Global instance
 teaching_planner = TeachingPlanner()
-

--- a/backend/tests/test_course_content_integration.py
+++ b/backend/tests/test_course_content_integration.py
@@ -5,10 +5,11 @@
 - API endpoints (progress/advance/lesson)
 """
 
+import inspect
 import pytest
 from unittest.mock import MagicMock
 
-from backend.models.models import Course, CourseProgress, LessonPlan, ProgressTracking
+from backend.models.models import Course, CourseProgress, LessonPlan
 from backend.services.prompt_builder.modules.course_content import CourseContentModule
 from backend.services.teaching_planner import TeachingPlanner
 
@@ -19,7 +20,6 @@ def _configure_db_mock(
     course=None,
     lesson_plans=None,
     course_progress=None,
-    progress_tracking=None,
 ):
     """Route db.query(Model) for LessonPlan-first code paths; empty LessonPlan → meta fallback."""
     if lesson_plans is None:
@@ -35,8 +35,6 @@ def _configure_db_mock(
             filtered.count.return_value = len(lesson_plans)
         elif model is CourseProgress:
             mock_query.filter.return_value.first.return_value = course_progress
-        elif model is ProgressTracking:
-            mock_query.filter.return_value.first.return_value = progress_tracking
         return mock_query
 
     db.query.side_effect = query_side_effect
@@ -246,7 +244,7 @@ class TestTeachingPlanner:
             "current_lesson_index": 0,
             "completed_lessons": [],
         })
-        _configure_db_mock(db, course=course, progress_tracking=None)
+        _configure_db_mock(db, course=course)
 
         result = self.planner.advance_lesson(db, course)
         assert "error" not in result
@@ -260,7 +258,7 @@ class TestTeachingPlanner:
             "current_lesson_index": 1,
             "completed_lessons": [0],
         })
-        _configure_db_mock(db, course=course, progress_tracking=None)
+        _configure_db_mock(db, course=course)
 
         result = self.planner.advance_lesson(db, course)
         assert course.meta["current_lesson_index"] == 1  # stays at last
@@ -271,7 +269,7 @@ class TestTeachingPlanner:
             "generated_lessons": [{"title": "L1"}, {"title": "L2"}, {"title": "L3"}],
             "current_lesson_index": 0,
         })
-        _configure_db_mock(db, course=course, progress_tracking=None)
+        _configure_db_mock(db, course=course)
 
         result = self.planner.set_lesson(db, course, 2)
         assert "error" not in result
@@ -316,7 +314,7 @@ class TestTeachingPlanner:
             "current_lesson_index": 1,
             "completed_lessons": [0],
         })
-        _configure_db_mock(db, course=course, progress_tracking=None)
+        _configure_db_mock(db, course=course)
 
         result = self.planner.advance_lesson(db, course)
         assert result["course_completed"] is True
@@ -334,20 +332,10 @@ class TestTeachingPlanner:
         progress = self.planner.get_progress(db, course)
         assert progress["course_completed"] is False
 
-    def test_record_progress_does_not_bump_existing_mastery(self):
+    def test_teaching_planner_has_no_progress_tracking_writer(self):
         """[TODO-T5] Revisiting a lesson must not increment mastery — that
         was the bug where set_lesson(1) after advance_lesson(2) silently
         added +20 to lesson 1's mastery on every revisit."""
-        db = MagicMock()
-        existing = MagicMock()
-        existing.mastery_level = 60
-        course = self._make_course(meta={
-            "generated_lessons": [{"title": "L1"}],
-            "current_lesson_index": 0,
-        })
-        _configure_db_mock(db, course=course, progress_tracking=existing)
-
-        self.planner._record_lesson_progress(db, course, 0)
-
-        assert existing.mastery_level == 60, "revisit must not change mastery_level"
-        assert not db.add.called, "must not insert another row when one exists"
+        source = inspect.getsource(TeachingPlanner)
+        assert "_record_lesson_progress" not in source
+        assert "ProgressTracking" not in source

--- a/backend/tests/test_lesson_pointer_single_source.py
+++ b/backend/tests/test_lesson_pointer_single_source.py
@@ -541,3 +541,72 @@ class TestA23CanonicalLessonReads:
         next_def = rest.index("\ndef ")
         chunk = source[start: start + 1 + next_def]
         assert "query(ProgressTracking)" not in chunk
+
+    def test_save_export_lesson_snapshot_uses_canonical_progress(self, client, auth_headers, db_session):
+        user = db_session.query(User).filter_by(username="testuser").one()
+
+        world = World(user_id=user.id, name="Save Export World", description="")
+        db_session.add(world)
+        db_session.flush()
+
+        course = Course(
+            world_id=world.id,
+            name="Save Export Course",
+            meta={
+                "generated_lessons": [
+                    {"title": "Meta 0", "concepts": ["old-a"]},
+                    {"title": "Meta 1", "concepts": ["old-b"]},
+                ],
+                "current_lesson_index": 9,
+                "completed_lessons": [],
+            },
+        )
+        db_session.add(course)
+        db_session.flush()
+
+        for i, title in enumerate(["L0", "L1"]):
+            db_session.add(
+                LessonPlan(
+                    course_id=course.id,
+                    order_index=i,
+                    title=title,
+                    concepts=[f"c{i}"],
+                )
+            )
+        db_session.add(
+            CourseProgress(
+                course_id=course.id,
+                user_id=user.id,
+                current_lesson_index=1,
+                completed_lesson_ids=[0],
+            )
+        )
+        db_session.commit()
+
+        start = client.post(f"/api/courses/{course.id}/start", headers=auth_headers)
+        assert start.status_code == 200
+        session_id = start.json()["session_id"]
+
+        checkpoint = client.post(
+            "/api/checkpoints",
+            json={
+                "world_id": world.id,
+                "save_name": "a2-canonical-export",
+                "session_id": session_id,
+            },
+            headers=auth_headers,
+        )
+        assert checkpoint.status_code == 200
+
+        detail = client.get(
+            f"/api/checkpoints/{checkpoint.json()['id']}",
+            headers=auth_headers,
+        )
+        assert detail.status_code == 200
+
+        lesson_snapshot = detail.json()["state"]["progress_snapshot"]["lessons"]
+        assert lesson_snapshot["current_index"] == 1
+        assert lesson_snapshot["completed_lesson_ids"] == [0]
+        assert lesson_snapshot["progress_pct"] == 50.0
+        assert [item["title"] for item in lesson_snapshot["items"]] == ["L0", "L1"]
+        assert [item["status"] for item in lesson_snapshot["items"]] == ["completed", "current"]

--- a/backend/tests/test_mastery_tracker.py
+++ b/backend/tests/test_mastery_tracker.py
@@ -348,7 +348,7 @@ class TestMasteryTrackerRealDB:
             course_id=course_id, world_id=world_id, user_id=user_id,
         )
 
-        teaching_planner._record_lesson_progress(db_session, course, 0)
+        teaching_planner.set_lesson(db_session, course, 0)
         db_session.flush()
 
         # Concept side: ConceptMastery (canonical)

--- a/backend/tests/test_progress_facade.py
+++ b/backend/tests/test_progress_facade.py
@@ -133,7 +133,7 @@ class TestProgressFacadeBehavior:
         after = db_session.query(ProgressTracking).count()
         assert after == before
 
-    def test_rollback_flag_restores_progress_tracking_insert(
+    def test_rollback_flag_restores_archive_progress_tracking_insert(
         self, client, auth_headers, db_session, monkeypatch,
     ):
         from backend.core.config import get_settings
@@ -164,10 +164,14 @@ class TestProgressFacadeBehavior:
         import inspect
 
         from backend.api.routes import archive as archive_routes
+        from backend.services import teaching_planner as teaching_planner_module
 
         source = inspect.getsource(archive_routes.create_progress)
         assert "progress_facade.create_progress_compat" in source
         assert "ProgressTracking(" not in source
+
+        planner_source = inspect.getsource(teaching_planner_module.TeachingPlanner)
+        assert "ProgressTracking" not in planner_source
 
         textbook_source = open(
             __file__.replace("test_progress_facade.py", "../api/routes/textbook.py"),


### PR DESCRIPTION
## Summary
- complete A2-4 by structurally removing the lesson `ProgressTracking` writer from `teaching_planner`
- complete A2-3b by exporting checkpoint lesson progress from canonical `CourseProgress`/`LessonPlan` snapshot data
- keep A2-5 archive compat canonicalization out of this PR

## Scope
- `backend/services/teaching_planner.py`
- `backend/api/routes/save.py`
- targeted regression tests for progress facade, lesson pointer single source, save export, and mastery tracker

## Behavior
- `advance_lesson`, `set_lesson`, and auto-advance no longer write lesson rows into `ProgressTracking`
- checkpoint save/export now serializes canonical lesson progress (`current_index`, completion state, progress pct, lesson items)
- archive compat GET/response shaping beyond the existing behavior is unchanged in this PR

## Validation
- `python -m pytest backend\tests\test_progress_facade.py backend\tests\test_lesson_pointer_single_source.py backend\tests\test_course_content_integration.py backend\tests\test_mastery_tracker.py -q`
- `cd frontend && npm run build`（根目录 `package.json` 无 build script）

## Notes
- workflow/agent migration docs were split into a separate local commit and are not included here
- A2-5 archive compat canonicalization remains intentionally untouched