### PR TITLE
refactor(v1.0.5): Seam A2-5 — archive GET compat canonicalization

### DIFF
--- a/backend/services/progress_facade.py
+++ b/backend/services/progress_facade.py
@@ -57,9 +57,142 @@ def skip_progress_tracking_writes() -> bool:
 
 def progress_compat_headers(course_id: int | None = None) -> dict[str, str]:
     headers = {"Deprecation": "true"}
+    if use_progress_facade():
+        headers["X-Progress-Compat-Mode"] = "canonical-concept-mastery"
     if course_id is not None:
         headers["Link"] = f'</api/courses/{course_id}/progress>; rel="successor-version"'
     return headers
+
+
+def _courses_for_user(
+    db: Session,
+    user_id: int,
+    course_id: int | None = None,
+) -> list[Course]:
+    query = (
+        db.query(Course)
+        .join(World, Course.world_id == World.id)
+        .filter(World.user_id == user_id)
+    )
+    if course_id is not None:
+        query = query.filter(Course.id == course_id)
+    return query.all()
+
+
+def _course_concept_ids(db: Session, course: Course) -> list[str]:
+    concepts: list[str] = []
+    for lesson in teaching_planner._get_lessons(db, course):
+        for concept in lesson.get("concepts") or []:
+            if concept not in concepts:
+                concepts.append(concept)
+    return concepts
+
+
+def _query_legacy_progress_rows(
+    db: Session,
+    user_id: int,
+    course_id: int | None = None,
+) -> list[ProgressTracking]:
+    query = (
+        db.query(ProgressTracking)
+        .join(Course, ProgressTracking.course_id == Course.id)
+        .join(World, Course.world_id == World.id)
+        .filter(
+            ProgressTracking.user_id == user_id,
+            World.user_id == user_id,
+        )
+    )
+    if course_id is not None:
+        query = query.filter(ProgressTracking.course_id == course_id)
+    return list(query.all())
+
+
+def _fsrs_next_review_by_concept(
+    db: Session,
+    user_id: int,
+    concept_ids: list[str],
+) -> dict[str, datetime | None]:
+    if not concept_ids:
+        return {}
+    rows = (
+        db.query(FSRSState)
+        .filter(
+            FSRSState.user_id == user_id,
+            FSRSState.concept_id.in_(concept_ids),
+        )
+        .all()
+    )
+    return {row.concept_id: row.next_review for row in rows}
+
+
+def _list_merged_compat_progress_rows(
+    db: Session,
+    user_id: int,
+    course_id: int | None = None,
+) -> list[ProgressTracking | CompatProgressView]:
+    """A2-5: merge ConceptMastery (+ FSRS) into archive GET /progress compat rows."""
+    pt_rows = _query_legacy_progress_rows(db, user_id, course_id)
+    pt_by_key = {(row.course_id, row.topic): row for row in pt_rows}
+
+    merged: list[ProgressTracking | CompatProgressView] = []
+    seen_keys: set[tuple[int, str]] = set()
+
+    for course in _courses_for_user(db, user_id, course_id):
+        concept_ids = _course_concept_ids(db, course)
+        if not concept_ids:
+            continue
+
+        cm_rows = (
+            db.query(ConceptMastery)
+            .filter(
+                ConceptMastery.user_id == user_id,
+                ConceptMastery.concept_id.in_(concept_ids),
+            )
+            .all()
+        )
+        fsrs_reviews = _fsrs_next_review_by_concept(
+            db, user_id, [row.concept_id for row in cm_rows],
+        )
+
+        for cm in cm_rows:
+            key = (course.id, cm.concept_id)
+            seen_keys.add(key)
+            pt = pt_by_key.get(key)
+            next_review = fsrs_reviews.get(cm.concept_id)
+            if next_review is None and pt is not None:
+                next_review = pt.next_review
+            last_review = cm.last_review or (pt.last_review if pt else None)
+
+            if pt is not None:
+                merged.append(
+                    CompatProgressView(
+                        id=pt.id,
+                        user_id=user_id,
+                        course_id=course.id,
+                        topic=cm.concept_id,
+                        mastery_level=cm.mastery_level or 0,
+                        next_review=next_review,
+                        last_review=last_review,
+                    )
+                )
+            else:
+                merged.append(
+                    _synthetic_compat_row(
+                        user_id=user_id,
+                        course_id=course.id,
+                        topic=cm.concept_id,
+                        mastery_level=cm.mastery_level or 0,
+                        next_review=next_review,
+                        last_review=last_review,
+                        source_id=cm.id,
+                    )
+                )
+
+    for key, pt in pt_by_key.items():
+        if key not in seen_keys:
+            merged.append(pt)
+
+    return merged
 
 
 def get_lesson_progress(db: Session, course: Course, user_id: int) -> dict[str, Any]:
@@ -100,19 +233,10 @@ def list_compat_progress_rows(
     user_id: int,
     course_id: int | None = None,
 ) -> list[ProgressTracking | CompatProgressView]:
-    """Read legacy ProgressTracking rows for archive GET /progress."""
-    query = (
-        db.query(ProgressTracking)
-        .join(Course, ProgressTracking.course_id == Course.id)
-        .join(World, Course.world_id == World.id)
-        .filter(
-            ProgressTracking.user_id == user_id,
-            World.user_id == user_id,
-        )
-    )
-    if course_id is not None:
-        query = query.filter(ProgressTracking.course_id == course_id)
-    return list(query.all())
+    """Archive GET /progress — canonical ConceptMastery merge when facade enabled."""
+    if not use_progress_facade():
+        return _query_legacy_progress_rows(db, user_id, course_id)
+    return _list_merged_compat_progress_rows(db, user_id, course_id)
 
 
 def _upsert_concept_mastery(

--- a/backend/tests/test_progress_facade.py
+++ b/backend/tests/test_progress_facade.py
@@ -78,6 +78,10 @@ class TestProgressFacadeBehavior:
         assert archive_resp.status_code == 200
         assert archive_resp.headers.get("Deprecation") == "true"
         assert (
+            archive_resp.headers.get("X-Progress-Compat-Mode")
+            == "canonical-concept-mastery"
+        )
+        assert (
             archive_resp.headers.get("X-Canonical-Current-Lesson-Index")
             == str(textbook_index)
         )
@@ -181,3 +185,95 @@ class TestProgressFacadeBehavior:
         assert "teaching_planner.get_progress" not in textbook_source.split(
             "get_course_progress",
         )[1].split("def advance_lesson")[0]
+
+
+class TestA25ArchiveCompatCanonical:
+    def test_archive_get_prefers_concept_mastery_over_stale_pt(
+        self, client, auth_headers, db_session,
+    ):
+        user = db_session.query(User).filter_by(username="testuser").one()
+        course_id = _seed_course_with_lessons(db_session, user.id)
+
+        stale = ProgressTracking(
+            course_id=course_id,
+            user_id=user.id,
+            topic="c1",
+            mastery_level=20,
+        )
+        db_session.add(stale)
+        db_session.add(
+            ConceptMastery(
+                user_id=user.id,
+                concept_id="c1",
+                mastery_level=88,
+            )
+        )
+        db_session.commit()
+
+        resp = client.get(
+            f"/api/progress?course_id={course_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Progress-Compat-Mode") == "canonical-concept-mastery"
+        rows = resp.json()
+        c1 = next(row for row in rows if row["topic"] == "c1")
+        assert c1["mastery_level"] == 88
+
+    def test_archive_get_includes_concept_mastery_without_pt_row(
+        self, client, auth_headers, db_session,
+    ):
+        user = db_session.query(User).filter_by(username="testuser").one()
+        course_id = _seed_course_with_lessons(db_session, user.id)
+
+        db_session.add(
+            ConceptMastery(
+                user_id=user.id,
+                concept_id="c2",
+                mastery_level=72,
+            )
+        )
+        db_session.commit()
+
+        resp = client.get(
+            f"/api/progress?course_id={course_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        topics = {row["topic"]: row for row in resp.json()}
+        assert topics["c2"]["mastery_level"] == 72
+        assert topics["c2"]["id"] < 0
+
+    def test_archive_get_keeps_legacy_pt_when_no_concept_mastery(
+        self, client, auth_headers, db_session,
+    ):
+        user = db_session.query(User).filter_by(username="testuser").one()
+        course_id = _seed_course_with_lessons(db_session, user.id)
+
+        db_session.add(
+            ProgressTracking(
+                course_id=course_id,
+                user_id=user.id,
+                topic="legacy_only",
+                mastery_level=45,
+            )
+        )
+        db_session.commit()
+
+        resp = client.get(
+            f"/api/progress?course_id={course_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        legacy = next(row for row in resp.json() if row["topic"] == "legacy_only")
+        assert legacy["mastery_level"] == 45
+        assert legacy["id"] > 0
+
+    def test_list_compat_progress_rows_does_not_query_pt_only_when_facade_on(self):
+        import inspect
+
+        from backend.services import progress_facade as pf_module
+
+        source = inspect.getsource(pf_module.list_compat_progress_rows)
+        assert "_list_merged_compat_progress_rows" in source
+        assert "use_progress_facade()" in source


### PR DESCRIPTION
## Overview
Seam A2-5（Option A）：`list_compat_progress_rows()` 合并 canonical `ConceptMastery`（+ FSRS `next_review`），使 archive GET `/progress` 响应体不再仅依赖 stale `ProgressTracking` 读。

## Change List
- `backend/services/progress_facade.py`：`_list_merged_compat_progress_rows`；facade 开启时 CM 优先、legacy PT 无 CM 时保留
- `backend/tests/test_progress_facade.py`：`TestA25ArchiveCompatCanonical` + compat mode 响应头断言

## Self-Check
- [x] 已运行 `pytest backend/tests/test_progress_facade.py -q`（9 passed）
- [x] 已评估回归风险（`USE_PROGRESS_FACADE=false` 仍走纯 PT 读）
- [x] 已检查兼容性（ProgressTracking 响应 schema 不变；synthetic 负 id 惯例保留）
- [x] 无无关改动混入
- [x] 未在业务层/脚本中直接赋值 User LLM 字段

## Reviewer Focus
- [ ] stale PT + CM 并存时 archive GET 返回 CM `mastery_level`
- [ ] 无 CM 的 legacy PT 行仍出现在列表中
- [ ] `X-Progress-Compat-Mode: canonical-concept-mastery` 与 `X-Canonical-Current-Lesson-Index` 仍正确

### 自查项 - LLM 用户配置写入规范
- [x] 未直接赋值 user LLM 字段
- [x] 所有LLM配置更新统一使用 update_provider_settings / update_generation_params
- [x] 仅 tests fixture 允许裸写

## Linked Issues
Closes #266